### PR TITLE
fix: google search metadata

### DIFF
--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -1,4 +1,11 @@
-Name: Google Search 
+---
+Name: Google Search
+Metadata: bundle: true
+Description: Tools for using Google Search
+Share Tools: Search
+
+---
+Name: Search
 Share Context: github.com/gptscript-ai/credentials/model-provider
 Description: Search Google with a given query and return relevant information from the search results
 Args: query: A question, statement, or topic to search with (required)
@@ -7,5 +14,9 @@ Args: maxResults: The maximum number of search results to gather relevant inform
 #!/usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run tool
 
 ---
-!metadata:*:Category
+!metadata:*:category
 Google Search
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/list-magnifying-glass-duotone.svg


### PR DESCRIPTION
- Add Google Search tool bundle to align with established pattern
- Add an icon for Google Search
- Fix category metadata typo that was preventing the UI from discovering
  the Google Search category
