### PR TITLE
fix: make google search refinement more conservative 

### DIFF
--- a/google/search/src/refineQuery.ts
+++ b/google/search/src/refineQuery.ts
@@ -5,7 +5,7 @@ export async function refineQuery(query: string): Promise<string> {
     agents: [],
     arguments: { type: 'object' },
     chat: false,
-    context: [],
+    context: ['Current Date and Time from github.com/otto8-ai/tools/time'],
     credentials: [],
     description: '',
     export: [],
@@ -19,8 +19,8 @@ export async function refineQuery(query: string): Promise<string> {
     tools: [],
     modelName: 'gpt-4o-mini',
     instructions: `
-    Refine the query below to improve its Google Search results.
-    The refined query should preserve the inferred intent of the original query.
+    Refine the query below to improve the quality of its Google Search results if necessary.
+    Be conservative with refinements so that the original meaning is more or less preserved.
     Do not quote the output.
 
     Query: ${query}

--- a/google/search/src/search.ts
+++ b/google/search/src/search.ts
@@ -32,7 +32,6 @@ export async function search(
 
       const url = $(element).attr('href') ?? '';
       if (url && !url.includes('youtube.com/watch?v') && !foundURLs.has(url)) {
-        console.warn(url)
         foundURLs.add(url);
         contentsPromises.push(getMarkdown(noJSPages[contentsPromises.length], url).then(content => {
           return content ? { url, content } : null;

--- a/google/search/src/server.ts
+++ b/google/search/src/server.ts
@@ -47,7 +47,7 @@ const tool: gptscript.ToolDef = {
     required: ['search']
   },
   chat: false,
-  context: [],
+  context: ['Current Date and Time from github.com/otto8-ai/tools/time'],
   credentials: [],
   description: '',
   export: [],

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -8,10 +8,11 @@ Share Tools: Search
 Name: Search
 Share Context: github.com/gptscript-ai/credentials/model-provider
 Description: Search Google with a given query and return relevant information from the search results
+JSON Response: true
 Args: query: A question, statement, or topic to search with (required)
 Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3)
 
-#!/usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run tool
+#!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool
 
 ---
 !metadata:*:category

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -6,7 +6,7 @@ Share Tools: Search
 
 ---
 Name: Search
-Share Context: github.com/gptscript-ai/credentials/model-provider
+Credential: github.com/gptscript-ai/credentials/model-provider
 Description: Search Google with a given query and return relevant information from the search results
 JSON Response: true
 Args: query: A question, statement, or topic to search with (required)


### PR DESCRIPTION
Make Google Search query refinement more conservative by adding the `Current Date and Time` context tool to internal tool calls and tweaking the refinement tool prompt. This should help prevent the refined query changing too much and negatively impacting the results, especially when the query involves dates.

e.g. before this change "Who won the 2024 Super Bowl?" is refined to "2024 Super Bow predictions and favorites" which results in content from old articles being returned. After adding this change, the query is refined to "Who won the Super Bowl 2024" which results in content that can actually answer the question.

This change also suppresses `npm run` script body printing to ensure the tool produces valid JSON.