### PR TITLE
fix: allow scraping URLs with full domains

### DIFF
--- a/knowledge/data-sources/website/colly.go
+++ b/knowledge/data-sources/website/colly.go
@@ -156,6 +156,8 @@ func (c *Colly) Crawl(metadata *Metadata, metadataPath string, workingDir string
 						parsedLink.Path = ""
 					}
 					e.Request.Visit(parsedLink.String())
+				} else if !strings.HasPrefix(link, "#") {
+					e.Request.Visit(linkURL.String())
 				}
 			}
 		})


### PR DESCRIPTION
Added another check so that urls like
`[Kube API Down](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown/)` are also scraped.

This now covers the case where the link URL does contain a host entry, not just a path.