### PR TITLE
enhance: use system browser for google search

### DIFF
--- a/google/search/package-lock.json
+++ b/google/search/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "hasInstallScript": true,
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.5",
         "@playwright/test": "^1.41.2",

--- a/google/search/package.json
+++ b/google/search/package.json
@@ -2,8 +2,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsnd --respawn src/server.ts",
-    "tool": "node --no-warnings --loader ts-node/esm src/server.ts",
-    "postinstall": "npx playwright install chromium"
+    "tool": "node --no-warnings --loader ts-node/esm src/server.ts"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.5",

--- a/google/search/src/context.ts
+++ b/google/search/src/context.ts
@@ -1,4 +1,4 @@
-import { type BrowserContext, chromium } from '@playwright/test'
+import { type BrowserContext, chromium, firefox } from '@playwright/test'
 import { randomInt } from 'node:crypto'
 
 export interface ContextAndSessionDir {
@@ -6,20 +6,94 @@ export interface ContextAndSessionDir {
   sessionDir: string
 }
 
-export async function getNewContext (workspaceDir: string, javaScriptEnabled: boolean): Promise<ContextAndSessionDir> {
+export async function getNewContext(workspaceDir: string, javaScriptEnabled: boolean): Promise<ContextAndSessionDir> {
   const sessionDir = workspaceDir + '/afti_browser_session_' + randomInt(1, 1000000).toString()
   let context: BrowserContext
 
-  context = await chromium.launchPersistentContext(
-    sessionDir,
-    {
-      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-      headless: true,
-      viewport: null,
-      args: ['--start-maximized', '--disable-blink-features=AutomationControlled'],
-      ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
-      javaScriptEnabled
-    })
+  const browser = await getSystemBrowser()
+  switch (browser) {
+    case 'chromium':
+      context = await chromium.launchPersistentContext(
+        sessionDir,
+        {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+          headless: true,
+          viewport: null,
+          args: ['--start-maximized', '--disable-blink-features=AutomationControlled'],
+          ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
+          javaScriptEnabled
+        })
+      break
+    case 'chrome':
+      context = await chromium.launchPersistentContext(
+        sessionDir,
+        {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+          headless: true,
+          viewport: null,
+          channel: 'chrome',
+          args: ['--start-maximized', '--disable-blink-features=AutomationControlled'],
+          ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
+          javaScriptEnabled
+        })
+      break
+    case 'firefox':
+      context = await firefox.launchPersistentContext(
+        sessionDir,
+        {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/89.0 Safari/537.36',
+          headless: true,
+          viewport: null,
+          javaScriptEnabled
+        })
+      break
+    case 'edge':
+      context = await chromium.launchPersistentContext(
+        sessionDir,
+        {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.64',
+          headless: true,
+          viewport: null,
+          channel: 'msedge',
+          args: ['--start-maximized', '--disable-blink-features=AutomationControlled'],
+          ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
+          javaScriptEnabled
+        })
+      break
+    default:
+      throw new Error(`Unknown browser: ${browser}`)
+  }
 
   return { context, sessionDir }
+}
+
+let systemBrowser: string | undefined;
+
+async function getSystemBrowser(): Promise<string> {
+  if (systemBrowser) {
+    return systemBrowser
+  }
+
+  const browsers = [
+    { name: 'Chrome', launchFunction: async () => await chromium.launch({ channel: 'chrome' }) },
+    { name: 'Edge', launchFunction: async () => await chromium.launch({ channel: 'msedge' }) },
+    { name: 'Firefox', launchFunction: async () => await firefox.launch() },
+    { name: 'Chromium', launchFunction: async () => await chromium.launch() }
+  ]
+
+  const errors = []
+  for (const browser of browsers) {
+    try {
+      const browserInstance = await browser.launchFunction()
+      void browserInstance.close()
+
+      systemBrowser = browser.name.toLowerCase()
+
+      return browser.name.toLowerCase()
+    } catch (error) {
+      errors.push(error)
+    }
+  }
+
+  throw new Error(`No supported browsers (Chrome, Edge, Firefox) are installed. ${errors}`)
 }


### PR DESCRIPTION
Don't rely on post-install script to install chromium for google search.
Instead, use whatever browser has already been installed on the system.
Supports Chrome, Chromium, Firefox, and Edge.

