### PR TITLE
Fix: make website tool output to stdout, handle error gracefully

### DIFF
--- a/knowledge/data-sources/onedrive/main.go
+++ b/knowledge/data-sources/onedrive/main.go
@@ -154,14 +154,14 @@ func main() {
 		if err := writeMetadata(metadata, metadataPath); err != nil {
 			logrus.Error(err)
 		}
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	metadata.Output.Status = ""
 	metadata.Output.Error = ""
 	if err := writeMetadata(metadata, metadataPath); err != nil {
 		logrus.Error(err)
-		os.Exit(1)
+		os.Exit(0)
 	}
 }
 

--- a/knowledge/data-sources/website/main.go
+++ b/knowledge/data-sources/website/main.go
@@ -52,6 +52,8 @@ type FileDetails struct {
 }
 
 func main() {
+	logrus.SetOutput(os.Stdout)
+
 	var err error
 	workingDir := os.Getenv("GPTSCRIPT_WORKSPACE_DIR")
 	if workingDir == "" {
@@ -99,7 +101,7 @@ func main() {
 	}
 
 	if mode == "colly" {
-		NewColly().Crawl(&metadata, metadataPath, workingDir)
+		CrawlColly(&metadata, metadataPath, workingDir)
 	} else if mode == "firecrawl" {
 		NewFirecrawl().Crawl(&metadata, metadataPath, workingDir)
 	}


### PR DESCRIPTION
1. Fix onedrive so that when error is written in metadata, don't exit with 1 so that error can be propagated back.
2. Fix website to show logs from thread.
https://github.com/otto8-ai/otto8/issues/230
