### PR TITLE
fix: prevent outlook mail forwarding

### DIFF
--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -106,6 +106,8 @@ Do not output mail folder IDs or message IDs because they are not helpful for th
 When printing a list of messages for the user, include the body preview. When printing a single message and its details, print the full body. Always include the email link.
 When printing a single message or a list of messages, use Markdown formatting.
 
+Do not attempt to forward emails. Email forwarding is not supported.
+
 ## End of instructions for using the Microsoft Outlook Mail tools
 
 ---


### PR DESCRIPTION
Add a line to the context for Outlook Mail Tools that prevents the LLM from attempting to forward emails. This will be added as a standalone tool.

Addresses https://github.com/otto8-ai/otto8/issues/102