### PR TITLE
enhance: add default timezone tool to outlook calendar

### DIFF
--- a/outlook/calendar/credential/tool.gpt
+++ b/outlook/calendar/credential/tool.gpt
@@ -9,5 +9,7 @@ Share Credential: ../../../oauth2 as outlook.calendar.write
             Group.Read.All
             Group.ReadWrite.All
             GroupMember.Read.All
-            User.Read offline_access" as scope
+            User.Read
+            MailboxSettings.Read
+            offline_access" as scope
 Type: credential

--- a/outlook/calendar/main.go
+++ b/outlook/calendar/main.go
@@ -110,6 +110,11 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+	case "getDefaultTimezone":
+		if err := commands.GetDefaultTimezone(context.Background()); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	default:
 		fmt.Printf("Unknown command: %q\n", command)
 		os.Exit(1)

--- a/outlook/calendar/pkg/commands/getDefaultTimezone.go
+++ b/outlook/calendar/pkg/commands/getDefaultTimezone.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gptscript-ai/tools/outlook/calendar/pkg/client"
+	"github.com/gptscript-ai/tools/outlook/calendar/pkg/global"
+)
+
+func GetDefaultTimezone(ctx context.Context) error {
+	c, err := client.NewClient(global.ReadOnlyScopes)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	settings, err := c.Me().MailboxSettings().Get(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get mailbox settings: %w", err)
+	}
+
+	if tz := settings.GetTimeZone(); tz != nil && *tz != "" {
+		fmt.Println("The user's default timezone is", *tz)
+	} else {
+		fmt.Println("The user's default timezone not defined")
+	}
+
+	return nil
+}

--- a/outlook/calendar/pkg/global/global.go
+++ b/outlook/calendar/pkg/global/global.go
@@ -3,6 +3,6 @@ package global
 const CredentialEnv = "GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN"
 
 var (
-	ReadOnlyScopes = []string{"Calendars.Read", "Calendars.Read.Shared", "Group.Read.All", "GroupMember.Read.All", "User.Read"}
+	ReadOnlyScopes = []string{"Calendars.Read", "Calendars.Read.Shared", "Group.Read.All", "GroupMember.Read.All", "User.Read", "MailboxSettings.Read"}
 	AllScopes      = []string{"Calendars.Read", "Calendars.Read.Shared", "Calendars.ReadWrite", "Calendars.ReadWrite.Shared", "Group.Read.All", "Group.ReadWrite.All", "GroupMember.Read.All", "User.Read"}
 )

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -2,7 +2,7 @@
 Name: Outlook Calendar
 Metadata: bundle: true
 Description: Tools for interacting with Microsoft Outlook Calendar.
-Share Tools: List Calendars, List Events Today, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event
+Share Tools: List Calendars, List Events Today, List Events, Get Event Details, Create Event, Invite User To Event, Delete Event, Search Events, Respond To Event, Get Default Timezone
 
 ---
 Name: List Calendars
@@ -114,9 +114,17 @@ Param: response: The response to the invitation. Possible values are "accept", "
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool respondToEvent
 
 ---
+Name: Get Default Timezone
+Description: Get the user's default timezone.
+Credential: ./credential
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getDefaultTimezone
+
+---
 Name: Outlook Calendar Context
 Type: context
 Share Context: Current Date and Time from ../../time
+Share Tools: Get Default Timezone
 
 #!sys.echo
 
@@ -126,7 +134,9 @@ You have access to tools for the Microsoft Outlook Calendar API.
 
 Do not output calendar IDs or event IDs because they are not helpful for the user.
 
-You don't know the user's timezone. If they ask you to create or modify events, get clarification about their timezone and use it. If creating a date/time in the UTC timezone, it must end with 'Z' to properly denote it's for UTC.
+If creating a date/time in the UTC timezone, it must end with 'Z' to properly denote it's for UTC.
+
+If the user asks you to create or modify events, use their default timezone unless otherwise stated. If the user's default timezone isn't defined, ask them for clarification.
 
 ## End of instructions for using the Microsoft Outlook Calendar tools
 


### PR DESCRIPTION
Add the `Get Default Timezone` tool to `Outlook Calendar` to avoid prompting
the user for a timezone to use when creating or modifying events.

The tool returns the timezone from their Outlook mailbox settings.

Addresses: https://github.com/otto8-ai/otto8/issues/169

~Note: Some permissions need to be approved [here](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/b89e586d-26d5-4126-8012-dbad9c137417/defaultBlade/CallAnAPI) before I can test this (even though that page seems to say otherwise, the challenge page is still blocking me on admin approval for app permissions cc @drpebcak)~