### PR TITLE
chore: bump node-gptscript for Slack

### DIFF
--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#96d37241a06f844789ce54b279973348e25364c1",
+        "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#b42172c6b4f89b6bda6e7d422c2e486dcee1e99a",
         "@slack/web-api": "^7.3.2"
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
       "version": "v0.9.5",
-      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#96d37241a06f844789ce54b279973348e25364c1",
-      "integrity": "sha512-cZohsD0nPxIadD3kr74CSQ1hUx2PdVYf/8sp+oMOo6yBB4fqATSspnAt4opuXMaHcDDDgeaRCRajIgp0Jy6pdA==",
+      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#b42172c6b4f89b6bda6e7d422c2e486dcee1e99a",
+      "integrity": "sha512-VVKSlh5bisC4VSZ2fwldH8ImjlrauqyW/jeFHt5jhFMvRL7Qs6QOzfl3E1PXbRgPSD4pkgJ9OZLImsN6Rbzg8Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/slack/package.json
+++ b/slack/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
-    "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#96d37241a06f844789ce54b279973348e25364c1",
+    "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#b42172c6b4f89b6bda6e7d422c2e486dcee1e99a",
     "@slack/web-api": "^7.3.2"
   }
 }

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -7,10 +7,10 @@ export async function listChannels(webClient) {
     if (publicChannels.channels.length + privateChannels.channels.length > 10) {
         try {
             const gptscriptClient = new GPTScript()
-            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_DIR, 'slack_channels', 'list of slack channels')
+            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_ID, 'slack_channels', 'list of slack channels')
 
             for (const channel of [...publicChannels.channels, ...privateChannels.channels]) {
-                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_DIR, dataset.id, channel.name, channel.purpose.value || '', channelToString(channel))
+                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_ID, dataset.id, channel.name, channel.purpose.value || '', channelToString(channel))
             }
 
             console.log(`Created dataset with ID ${dataset.id} with ${publicChannels.channels.length + privateChannels.channels.length} channels`)
@@ -44,11 +44,11 @@ export async function searchChannels(webClient, query) {
     } else if (publicChannels.length + privateChannels.length > 10) {
         try {
             const gptscriptClient = new GPTScript()
-            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_DIR, `${query}_slack_channels`, `list of slack channels matching search query "${query}"`)
+            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_ID, `${query}_slack_channels`, `list of slack channels matching search query "${query}"`)
 
             for (const channel of [...publicChannels, ...privateChannels]) {
                 await gptscriptClient.addDatasetElement(
-                    process.env.GPTSCRIPT_WORKSPACE_DIR,
+                    process.env.GPTSCRIPT_WORKSPACE_ID,
                     dataset.id,
                     channel.name,
                     channel.purpose.value || '',
@@ -133,11 +133,11 @@ export async function search(webClient, query) {
     } else if (result.messages.matches.length > 10) {
         try {
             const gptscriptClient = new GPTScript()
-            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_DIR, `slack_search_${query}`, `search results for query "${query}"`)
+            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_ID, `slack_search_${query}`, `search results for query "${query}"`)
 
             for (const message of result.messages.matches) {
                 await gptscriptClient.addDatasetElement(
-                    process.env.GPTSCRIPT_WORKSPACE_DIR,
+                    process.env.GPTSCRIPT_WORKSPACE_ID,
                     dataset.id,
                     `${message.iid}_${message.ts}`,
                     "",
@@ -188,10 +188,10 @@ export async function listUsers(webClient) {
     if (users.members.length > 10) {
         try {
             const gptscriptClient = new GPTScript()
-            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_DIR, 'slack_users', 'list of slack users')
+            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_ID, 'slack_users', 'list of slack users')
 
             for (const user of users.members) {
-                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_DIR, dataset.id, user.name, user.profile.real_name, userToString(user))
+                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_ID, dataset.id, user.name, user.profile.real_name, userToString(user))
             }
 
             console.log(`Created dataset with ID ${dataset.id} with ${users.members.length} users`)
@@ -211,10 +211,10 @@ export async function searchUsers(webClient, query) {
     if (matchingUsers.length > 10) {
         try {
             const gptscriptClient = new GPTScript()
-            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_DIR, `${query}_slack_users`, `list of slack users matching search query "${query}"`)
+            const dataset = await gptscriptClient.createDataset(process.env.GPTSCRIPT_WORKSPACE_ID, `${query}_slack_users`, `list of slack users matching search query "${query}"`)
 
             for (const user of matchingUsers) {
-                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_DIR, dataset.id, user.name, user.profile.real_name, userToString(user))
+                await gptscriptClient.addDatasetElement(process.env.GPTSCRIPT_WORKSPACE_ID, dataset.id, user.name, user.profile.real_name, userToString(user))
             }
 
             console.log(`Created dataset with ID ${dataset.id} with ${matchingUsers.length} users`)


### PR DESCRIPTION
This updates the Slack tool to use the newest version of node-gptscript, which is needed to get datasets working again with Otto.