### PR TITLE
chore: skip datasets in areas where we need ordered elements

### DIFF
--- a/google/gmail/helpers.py
+++ b/google/gmail/helpers.py
@@ -60,26 +60,7 @@ async def list_messages(service, query, max_results):
             if not next_page_token:
                 break
 
-        if len(all_messages) > 10:
-            gptscript_client = gptscript.GPTScript()
-            try:
-                dataset = await gptscript_client.create_dataset(
-                    os.getenv("GPTSCRIPT_WORKSPACE_ID"),
-                    f"gmail_{query}",
-                    f"list of emails in Gmail for query {query}")
-                for message in all_messages:
-                    msg_id, msg_str = message_to_string(service, message)
-                    await gptscript_client.add_dataset_element(
-                        os.getenv("GPTSCRIPT_WORKSPACE_ID"),
-                        dataset.id,
-                        msg_id,
-                        msg_str
-                    )
-                print(f"Created dataset with ID {dataset.id} with {len(all_messages)} emails")
-                return
-            except Exception as e:
-                print("An error occurred while creating the dataset:", e, file=sys.stderr)
-                pass  # Ignore errors if we got any, and just print the results.
+		# TODO(g-linville): reintroduce datasets here once we can preserve element order
 
         display_list_messages(service, all_messages)
 
@@ -130,26 +111,7 @@ async def list_drafts(service, max_results=None):
             if not next_page_token:
                 break
 
-        if len(all_drafts) > 10:
-            try:
-                gptscript_client = gptscript.GPTScript()
-                dataset = await gptscript_client.create_dataset(
-                    os.getenv("GPTSCRIPT_WORKSPACE_ID"),
-                    "gmail_drafts",
-                    "list of drafts in Gmail")
-                for draft in all_drafts:
-                    draft_id, draft_str = draft_to_string(service, draft)
-                    await gptscript_client.add_dataset_element(
-                        os.getenv("GPTSCRIPT_WORKSPACE_ID"),
-                        dataset.id,
-                        draft_id,
-                        draft_str
-                    )
-                print(f"Created dataset with ID {dataset.id} with {len(all_drafts)} drafts")
-                return
-            except Exception as e:
-                print("An error occurred while creating the dataset:", e, file=sys.stderr)
-                pass  # Ignore errors if we got any, and just print the results.
+        # TODO(g-linville): reintroduce datasets here once we can preserve element order
 
         display_list_drafts(service, all_drafts)
 

--- a/outlook/mail/pkg/commands/listMessages.go
+++ b/outlook/mail/pkg/commands/listMessages.go
@@ -3,15 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 
-	"github.com/gptscript-ai/go-gptscript"
 	"github.com/gptscript-ai/tools/outlook/common/id"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/client"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/global"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/graph"
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/printers"
-	"github.com/gptscript-ai/tools/outlook/mail/pkg/util"
 )
 
 func ListMessages(ctx context.Context, folderID string) error {
@@ -37,42 +34,7 @@ func ListMessages(ctx context.Context, folderID string) error {
 		return fmt.Errorf("failed to list mail: %w", err)
 	}
 
-	if len(messages) > 10 {
-		gptscriptClient, err := gptscript.NewGPTScript()
-		if err != nil {
-			return fmt.Errorf("failed to create GPTScript client: %w", err)
-		}
-
-		workspaceID := os.Getenv("GPTSCRIPT_WORKSPACE_ID")
-
-		dataset, err := gptscriptClient.CreateDataset(ctx, workspaceID, fmt.Sprintf("%s_outlook_mail", folderID), "Outlook mail messages in folder "+folderID)
-		if err != nil {
-			return fmt.Errorf("failed to create dataset: %w", err)
-		}
-
-		var elements []gptscript.DatasetElement
-		for _, message := range messages {
-			messageStr, err := printers.MessageToString(message, false)
-			if err != nil {
-				return fmt.Errorf("failed to convert message to string: %w", err)
-			}
-
-			elements = append(elements, gptscript.DatasetElement{
-				DatasetElementMeta: gptscript.DatasetElementMeta{
-					Name:        util.Deref(message.GetId()),
-					Description: util.Deref(message.GetSubject()),
-				},
-				Contents: messageStr,
-			})
-		}
-
-		if err := gptscriptClient.AddDatasetElements(ctx, workspaceID, dataset.ID, elements); err != nil {
-			return fmt.Errorf("failed to add dataset elements: %w", err)
-		}
-
-		fmt.Printf("Created dataset with ID %s with %d messages\n", dataset.ID, len(messages))
-		return nil
-	}
+	// TODO(g-linville): reintroduce datasets here once we can preserve the order of the elements
 
 	return printers.PrintMessages(messages, false)
 }


### PR DESCRIPTION
At the moment, datasets do not preserve the order of elements anymore, which I need to fix. For now, let's just skip them in places where the order might matter, which I think is these three tools.