### PR TITLE
enhance: outlook calendar: support the creation of recurring meetings

### DIFF
--- a/outlook/calendar/main.go
+++ b/outlook/calendar/main.go
@@ -52,10 +52,11 @@ func main() {
 		}
 	case "createEvent":
 		info := graph.CreateEventInfo{
-			Attendees: strings.Split(os.Getenv("ATTENDEES"), ","),
-			Subject:   os.Getenv("SUBJECT"),
-			Location:  os.Getenv("LOCATION"),
-			Body:      os.Getenv("BODY"),
+			Attendees:  strings.Split(os.Getenv("ATTENDEES"), ","),
+			Subject:    os.Getenv("SUBJECT"),
+			Location:   os.Getenv("LOCATION"),
+			Body:       os.Getenv("BODY"),
+			Recurrence: os.Getenv("RECURRENCE"),
 		}
 
 		isOnline, err := strconv.ParseBool(os.Getenv("IS_ONLINE"))

--- a/outlook/calendar/pkg/recurrence/doc.md
+++ b/outlook/calendar/pkg/recurrence/doc.md
@@ -1,0 +1,372 @@
+# Recurring events
+
+Recurring events are an important part of Outlook calendaring. Whether it's a weekly one-on-one meeting with your manager or a division-wide review meeting that happens on the second Tuesday of each month, recurring events make it easy to create the event once and let the server fill in the rest of the series.
+
+The key bit of information that allows recurring events to "expand" into individual occurrences is the recurrence rule. The rule specifies both how often an event repeats and for how long.
+
+Each recurrence is made up of two parts: the recurrence pattern (how often) and the recurrence range (for how long).
+
+## Recurrence patterns
+
+The first part of a recurrence is the pattern. This specifies how often the event repeats. For example, an event could repeat "every 3 days," "every Thursday," or "on July 22 every year."
+
+Depending on the type of pattern, certain fields of the **recurrencePattern** are required, optional, or ignored.
+
+Note: even if a field is ignored, it is still validated. If a field has a set list of possible values, using a value outside the allowed set causes an error, even if that field is ignored.
+
+Let's take a look at each of the possible pattern types.
+
+### Daily
+
+The daily recurrence pattern causes an event to repeat based on a number of days between each occurrence.
+
+#### Relevant properties
+
+| Property | Relevance | Description                                           |
+|-|-|-|
+| interval | Required  | Specifies the number of days between each occurrence. |
+| type     | Required  | Must be set to daily.                                 |
+
+#### Examples
+
+Repeat this event every day=
+```json
+"pattern": {
+  "type": "daily",
+  "interval": 1
+}
+```
+
+Repeat this event every three days 
+```json
+"pattern": {
+  "type": "daily",
+  "interval": 3
+}
+```
+
+### Weekly
+
+The weekly recurrence pattern causes an event to repeat on the same day or days of the week, based on the number of weeks between each set of occurrences.
+
+#### Relevant properties
+
+* Property: daysOfWeek
+    * Relevance: Required
+    * Description: Specifies on which day(s) of the week the event occurs.
+* Property: firstDayOfWeek
+    * Relevance: Optional
+    * Description: Specifies which day is considered the first day of the week. Default value: Sunday.
+* Property: interval
+    * Relevance: Required
+    * Description: Specifies the number of weeks between each set of occurrences.
+* Property: type
+    * Relevance: Required
+    * Description: Must be set to weekly.
+
+
+#### Examples
+
+Repeat this event every Thursday
+```json
+"pattern": {
+  "type": "weekly",
+  "interval": 1,
+  "daysOfWeek": [ "Thursday" ]
+}
+```
+
+Repeat this event every other Monday and Tuesday
+```json
+"pattern": {
+  "type": "weekly",
+  "interval": 2,
+  "daysOfWeek": [
+    "Monday",
+    "Tuesday"
+  ]
+}
+```
+
+### Absolute monthly
+
+The absolute monthly pattern causes an event to repeat on the same day of the month (for example, the 15th), based on the number of months between each occurrence.
+
+#### Relevant properties
+
+| Property   | Relevance | Description                                             |
+|-|-|-|
+| dayOfMonth | Required  | Specifies on which day of the month the event occurs.   |
+| interval   | Required  | Specifies the number of months between each occurrence. |
+| type       | Required  | Must be set to absoluteMonthly.                         |
+
+#### Examples
+
+Repeat this event on the 15th of every month
+```json
+"pattern": {
+  "type": "absoluteMonthly",
+  "interval": 1,
+  "dayOfMonth": 15
+}
+```
+    
+Repeat this event quarterly (every 3 months) on the 7th
+    
+```json
+"pattern": {
+  "type": "absoluteMonthly",
+  "interval": 3,
+  "dayOfMonth": 7
+}
+```
+
+### Relative monthly
+
+The relative monthly pattern causes an event to repeat on the same day of the week in the same relative position in the month, based on the number of months between each occurrence. For example, "every second Wednesday of the month."
+
+#### Relevant properties
+
+* Property: daysOfWeek
+    * Relevance: Required
+    * Description: Specifies on which day(s) of the week the event can occur. Relative monthly events only occur once per month, so if more than one value is specified, the event falls on the first day that satisfies the pattern.
+* Property: index
+    * Relevance: Optional
+    * Description: Specifies on which instance of the allowed days specified in daysOfsWeek the event occurs, counted from the first instance in the month. Possible values: first, second, third, fourth, and last. Default value: first.
+* Property: interval
+    * Relevance: Required
+    * Description: Specifies the number of months between each occurrence.
+* Property: type
+    * Relevance: Required
+    * Description: Must be set to relativeMonthly.
+
+#### Examples
+
+Repeat this event on the second Wednesday of every month
+```json
+"pattern": {
+  "type": "relativeMonthly",
+  "interval": 1,
+  "daysOfWeek": [ "Wednesday" ],
+  "index": "second"
+}
+```
+
+Repeat this event on the first Thursday or Friday of every month
+```json
+"pattern": {
+  "type": "relativeMonthly",
+  "interval": 1,
+  "daysOfWeek": [ "Thursday", "Friday" ],
+  "index": "first"
+}
+```
+
+### Absolute yearly
+
+The absolute yearly pattern causes an event to repeat on the same month and day (for example, April 15), based on the number of years between each occurrence.
+
+#### Relevant properties
+
+| Property   | Relevance | Description                                            |
+|-|-|-|
+| dayOfMonth | Required  | Specifies on which day of the month the event occurs.  |
+| month      | Required  | Specifies in which month the event occurs.             |
+| interval   | Required  | Specifies the number of years between each occurrence. |
+| type       | Required  | Must be set to absoluteYearly.                         |
+
+#### Example
+
+Repeat this event on April 15 every year
+```json
+"pattern": {
+  "type": "absoluteYearly",
+  "interval": 1,
+  "dayOfMonth": 15,
+  "month": 4
+}
+```
+
+### Relative yearly
+
+The relative yearly pattern causes an event to repeat on the same day of the week in the same relative position in a specific month, based on the number of years between each occurrence. For example, "every last Wednesday of November."
+
+#### Relevant properties
+
+* Property: daysOfWeek
+  * Relevance: Required
+  * Description: Specifies on which day(s) of the week the event can occur. Relative yearly events only occur once per year, so if more than one value is specified, the event falls on the first day that satisfies the pattern.
+* Property: index
+  * Relevance: Optional
+  * Description: Specifies on which instance of the allowed days specified in daysOfsWeek the event occurs, counted from the first instance in the month. Possible values: first, second, third, fourth, and last. Default value: first.
+* Property: month
+  * Relevance: Required
+  * Description: Specifies in which month the event occurs.
+* Property: interval
+  * Relevance: Required
+  * Description: Specifies the number of years between each occurrence.
+* Property: type
+  * Relevance: Required
+  * Description: Must be set to relativeYearly.
+
+#### Examples
+
+Repeat this event on the last Wednesday of November every year
+```json
+"pattern": {
+  "type": "relativeYearly",
+  "interval": 1,
+  "daysOfWeek": [ "Wednesday" ],
+  "index": "last",
+  "month": 11
+}
+```
+
+## Recurrence ranges
+
+The second part of a recurrence is the range. This specifies how long the pattern repeats. For example, an event could end after 10 occurrences, by a specific date, or could have no end.
+
+Depending on the type of range, certain fields of **recurrenceRange** are required or ignored.
+
+Note: even if a field is ignored, it is still validated. If a field has a set list of possible values, using a value outside the allowed set causes an error, even if that field is ignored.
+
+Let's take a look at each of the possible range types.
+
+### Numbered range
+
+The numbered range causes an event to occur a fixed number of times (based on the pattern) from a start date.
+
+#### Relevant properties
+
+* Property: numberOfOccurrences
+    * Relevance: Required
+    * Description: Specifies the number of occurrences. Must be a positive integer.
+* Property: recurrenceTimeZone
+    * Relevance: Optional
+    * Description: Specifies the time zone for the startDate property. If not specified, the time zone of the event is used.
+* Property: startDate
+    * Relevance: Required
+    * Description: Specifies the date to start applying the pattern. The value of startDate MUST correspond to the date value of the start property on the event resource. Note that the first occurrence of the meeting may not occur on this date if it does not fit the pattern.
+* Property: type
+    * Relevance: Required
+    * Description: Must be set to numbered.
+
+#### Examples
+
+Repeat this event 10 times
+```json
+"range": {
+  "type": "numbered",
+  "startDate": "2017-04-02",
+  "numberOfOccurrences": 10
+}
+```
+
+### End date range
+
+The end date range causes an event to occur on all days that fit the applicable pattern between a start date and an end date.
+
+#### Relevant properties
+
+* Property: endDate
+  * Relevance: Required
+  * Description: Specifies the date to stop applying the pattern. Note that the last occurrence of the meeting may not occur on this date if it does not fit the pattern.
+* Property: recurrenceTimeZone
+  * Relevance: Optional
+  * Description: Specifies the time zone for the startDate and endDate properties. If not specified, the time zone of the event is used.
+* Property: startDate
+  * Relevance: Required
+  * Description: Specifies the date to start applying the pattern. The value of startDate MUST correspond to the date value of the start property on the event resource. Note that the first occurrence of the meeting may not occur on this date if it does not fit the pattern.
+* Property: type
+  * Relevance: Required
+  * Description: Must be set to endDate.
+
+#### Examples
+
+Repeat this event from July 1, 2017, to July 31, 2017
+```json
+"range": {
+  "type": "endDate",
+  "startDate": "2017-07-01",
+  "endDate": "2017-07-31"
+}
+```
+
+### No end range
+
+The no end range causes an event to occur on all days that fit the applicable pattern after a start date.
+
+#### Relevant properties
+
+* Property: recurrenceTimeZone
+    * Relevance: Optional
+    * Description: Specifies the time zone for the startDate property. If not specified, the time zone of the event is used.
+* Property: startDate
+    * Relevance: Required
+    * Description: Specifies the date to start applying the pattern. The value of startDate MUST correspond to the date value of the start property on the event resource. Note that the first occurrence of the meeting may not occur on this date if it does not fit the pattern.
+* Property: type
+    * Relevance: Required
+    * Description: Must be set to noEnd.
+
+#### Examples
+
+Repeat this event from May 15, 2017, forever
+```json
+"range": {
+  "type": "noEnd",
+  "startDate": "2017-05-15"
+}
+```
+
+## Using patterns and ranges to create recurring events
+
+Now that we've looked at patterns and ranges separately, let's look at how they work together and how they interact with the **start** and **end** properties on the event.
+
+### Creating a recurrence rule
+
+To create a recurrence rule, you must specify both a pattern and a range. Any pattern type can work with any range type. Here are a few examples.
+
+#### Examples
+
+**Meet from 1:00 PM to 1:30 PM every Monday starting September 4, 2017, until the end of the year**
+    
+*   The "every Monday" requirement is easily met by the `weekly` recurrence pattern type.
+*   The "until the end of the year" requirement indicates an `endDate` recurrence range type.
+    
+```json
+"recurrence": {
+  "pattern": {
+    "type": "weekly",
+    "interval": 1,
+    "daysOfWeek": [ "Monday" ]
+  },
+  "range": {
+    "type": "endDate",
+    "startDate": "2017-09-04",
+    "endDate": "2017-12-31"
+  }
+}
+```
+Because December 31, 2017, is on a Sunday, the last occurrence in this series will be on Monday, December 25.
+
+**Meet from 2:00 PM to 3:00 PM on the first Thursday of every other month starting August 29, 2017**
+
+*   The "first Thursday of every other month" requirement is achievable by using a relative monthly pattern. The "every other month" portion indicates that the **interval** should be set to `2`.
+*   Because there is no requirement on an end date, a `noEnd` range type can be used.
+
+```json
+"recurrence": {
+  "pattern": {
+    "type": "relativeMonthly",
+    "interval": 2,
+    "daysOfWeek": [ "Thursday" ],
+    "index": "first"
+  },
+  "range": {
+    "type": "noEnd",
+    "startDate": "2017-08-29"
+  }
+}
+```
+
+Because the value of **startDate** is after the first Thursday in August, the first occurrence of this series will be in September.

--- a/outlook/calendar/pkg/recurrence/recurrence.go
+++ b/outlook/calendar/pkg/recurrence/recurrence.go
@@ -1,0 +1,210 @@
+package recurrence
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gptscript-ai/go-gptscript"
+	"github.com/gptscript-ai/tools/outlook/calendar/pkg/util"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+//go:embed doc.md
+var doc string
+
+type Recurrence struct {
+	Pattern RecurrencePattern `json:"pattern"`
+	Range   RecurrenceRange   `json:"range"`
+}
+
+type RecurrencePattern struct {
+	DayOfMonth     int      `json:"dayOfMonth"`
+	DaysOfWeek     []string `json:"daysOfWeek"`
+	FirstDayOfWeek string   `json:"firstDayOfWeek"`
+	Index          string   `json:"index"`
+	Interval       int      `json:"interval"`
+	Month          int      `json:"month"`
+	RecurrenceType string   `json:"type"`
+}
+
+type RecurrenceRange struct {
+	EndDate             string `json:"endDate"`
+	StartDate           string `json:"startDate"`
+	NumberOfOccurrences int    `json:"numberOfOccurrences"`
+	RecurrenceType      string `json:"type"`
+}
+
+func (r Recurrence) ConvertForGraphAPI() (models.PatternedRecurrenceable, error) {
+	recurrenceable := models.NewPatternedRecurrence()
+
+	// Convert the range
+	rRange := models.NewRecurrenceRange()
+	if r.Range.EndDate != "" {
+		endDate, err := time.Parse(time.DateOnly, r.Range.EndDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse end date: %w", err)
+		}
+		rRange.SetEndDate(serialization.NewDateOnly(endDate))
+	}
+	if r.Range.StartDate != "" {
+		startDate, err := time.Parse(time.DateOnly, r.Range.StartDate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse start date: %w", err)
+		}
+		rRange.SetStartDate(serialization.NewDateOnly(startDate))
+	}
+	if r.Range.NumberOfOccurrences > 0 {
+		rRange.SetNumberOfOccurrences(util.Ptr(int32(r.Range.NumberOfOccurrences)))
+	}
+	rRange.SetTypeEscaped(util.Ptr(getRecurrenceRangeType(r.Range.RecurrenceType)))
+
+	// Convert the pattern
+	rPattern := models.NewRecurrencePattern()
+	if r.Pattern.DayOfMonth > 0 {
+		rPattern.SetDayOfMonth(util.Ptr(int32(r.Pattern.DayOfMonth)))
+	}
+	if len(r.Pattern.DaysOfWeek) > 0 {
+		rPattern.SetDaysOfWeek(util.Map(r.Pattern.DaysOfWeek, getDayOfWeek))
+	}
+	if r.Pattern.FirstDayOfWeek != "" {
+		rPattern.SetFirstDayOfWeek(util.Ptr(getDayOfWeek(r.Pattern.FirstDayOfWeek)))
+	}
+	if r.Pattern.Index != "" {
+		rPattern.SetIndex(util.Ptr(getWeekIndex(r.Pattern.Index)))
+	}
+	if r.Pattern.Interval > 0 {
+		rPattern.SetInterval(util.Ptr(int32(r.Pattern.Interval)))
+	}
+	if r.Pattern.Month > 0 {
+		rPattern.SetMonth(util.Ptr(int32(r.Pattern.Month)))
+	}
+	rPattern.SetTypeEscaped(util.Ptr(getRecurrencePatternType(r.Pattern.RecurrenceType)))
+
+	recurrenceable.SetPattern(rPattern)
+	recurrenceable.SetRangeEscaped(rRange)
+	return recurrenceable, nil
+}
+
+func getTool(description string) gptscript.ToolDef {
+	return gptscript.ToolDef{
+		JSONResponse: true,
+		Instructions: fmt.Sprintf(`
+Given the following description of a recurrence and documentation about Outlook recurrences,
+output a JSON object that describes the recurrence and matches the recurrence type in the documentation.
+The JSON object must include one top-level field called recurrence, which contains both a pattern and a range.
+
+Description: %s
+
+Documentation:
+
+%s`, description, doc),
+	}
+}
+
+func Generate(ctx context.Context, description string) (Recurrence, error) {
+	g, err := gptscript.NewGPTScript()
+	if err != nil {
+		return Recurrence{}, err
+	}
+
+	tool := getTool(description)
+
+	run, err := g.Evaluate(ctx, gptscript.Options{}, tool)
+	if err != nil {
+		return Recurrence{}, err
+	}
+
+	result, err := run.Text()
+	if err != nil {
+		return Recurrence{}, err
+	}
+
+	file, err := os.OpenFile("/Users/grant/recurrence.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err == nil {
+		file.WriteString(result + "\n")
+		file.Close()
+	}
+
+	var r struct {
+		Recurrence Recurrence `json:"recurrence"`
+	}
+	if err := json.Unmarshal([]byte(result), &r); err != nil {
+		return Recurrence{}, fmt.Errorf("failed to unmarshal recurrence: %w", err)
+	}
+
+	return r.Recurrence, nil
+}
+
+// It's annoying that we need to have all of these conversion functions, but the ones in the Graph SDK are bad.
+
+func getRecurrenceRangeType(t string) models.RecurrenceRangeType {
+	switch strings.ToLower(t) {
+	case "enddate":
+		return models.ENDDATE_RECURRENCERANGETYPE
+	case "numbered":
+		return models.NUMBERED_RECURRENCERANGETYPE
+	default:
+		return models.NOEND_RECURRENCERANGETYPE
+	}
+}
+
+func getRecurrencePatternType(t string) models.RecurrencePatternType {
+	switch strings.ToLower(t) {
+	case "daily":
+		return models.DAILY_RECURRENCEPATTERNTYPE
+	case "weekly":
+		return models.WEEKLY_RECURRENCEPATTERNTYPE
+	case "absolutemonthly":
+		return models.ABSOLUTEMONTHLY_RECURRENCEPATTERNTYPE
+	case "relativemonthly":
+		return models.RELATIVEMONTHLY_RECURRENCEPATTERNTYPE
+	case "absoluteyearly":
+		return models.ABSOLUTEYEARLY_RECURRENCEPATTERNTYPE
+	case "relativeyearly":
+		return models.RELATIVEYEARLY_RECURRENCEPATTERNTYPE
+	default:
+		return models.DAILY_RECURRENCEPATTERNTYPE
+	}
+}
+
+func getDayOfWeek(d string) models.DayOfWeek {
+	switch strings.ToLower(d) {
+	case "sunday":
+		return models.SUNDAY_DAYOFWEEK
+	case "monday":
+		return models.MONDAY_DAYOFWEEK
+	case "tuesday":
+		return models.TUESDAY_DAYOFWEEK
+	case "wednesday":
+		return models.WEDNESDAY_DAYOFWEEK
+	case "thursday":
+		return models.THURSDAY_DAYOFWEEK
+	case "friday":
+		return models.FRIDAY_DAYOFWEEK
+	case "saturday":
+		return models.SATURDAY_DAYOFWEEK
+	}
+	return models.SUNDAY_DAYOFWEEK
+}
+
+func getWeekIndex(w string) models.WeekIndex {
+	switch strings.ToLower(w) {
+	case "first":
+		return models.FIRST_WEEKINDEX
+	case "second":
+		return models.SECOND_WEEKINDEX
+	case "third":
+		return models.THIRD_WEEKINDEX
+	case "fourth":
+		return models.FOURTH_WEEKINDEX
+	case "last":
+		return models.LAST_WEEKINDEX
+	}
+	return models.FIRST_WEEKINDEX
+}

--- a/outlook/calendar/pkg/recurrence/recurrence.go
+++ b/outlook/calendar/pkg/recurrence/recurrence.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -15,6 +14,8 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 )
 
+// the source for doc.md: https://learn.microsoft.com/en-us/graph/outlook-schedule-recurring-events
+//
 //go:embed doc.md
 var doc string
 
@@ -123,12 +124,6 @@ func Generate(ctx context.Context, description string) (Recurrence, error) {
 	result, err := run.Text()
 	if err != nil {
 		return Recurrence{}, err
-	}
-
-	file, err := os.OpenFile("/Users/grant/recurrence.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err == nil {
-		file.WriteString(result + "\n")
-		file.Close()
 	}
 
 	var r struct {

--- a/outlook/calendar/pkg/recurrence/recurrence.go
+++ b/outlook/calendar/pkg/recurrence/recurrence.go
@@ -138,6 +138,16 @@ func Generate(ctx context.Context, description string) (Recurrence, error) {
 		return Recurrence{}, fmt.Errorf("failed to unmarshal recurrence: %w", err)
 	}
 
+	// The Outlook Calendar API is supposed to be able to support this, but it never seems to work,
+	// so we just ask the LLM to schedule multiple events if it is trying to do this.
+	if len(r.Recurrence.Pattern.DaysOfWeek) > 1 {
+		if r.Recurrence.Pattern.RecurrenceType == "relativeMonthly" {
+			return Recurrence{}, fmt.Errorf("error: a single monthly event cannot be scheduled on multiple days of the week - please schedule separate events instead")
+		} else if r.Recurrence.Pattern.RecurrenceType == "relativeYearly" {
+			return Recurrence{}, fmt.Errorf("error: a single yearly event cannot be scheduled on multiple days of the week - please schedule separate events instead")
+		}
+	}
+
 	return r.Recurrence, nil
 }
 

--- a/outlook/calendar/pkg/recurrence/recurrence_test.go
+++ b/outlook/calendar/pkg/recurrence/recurrence_test.go
@@ -187,11 +187,11 @@ func TestRecurrenceGeneration(t *testing.T) {
 		},
 		{
 			name:       "Relative Monthly Numbered",
-			recurrence: "every three months on the third Tuesday and Wednesday, for 18 events, starting 3/3/27",
+			recurrence: "every three months on the third Tuesday, for 18 events, starting 3/3/27",
 			expected: Recurrence{
 				Pattern: RecurrencePattern{
 					Index:          "third",
-					DaysOfWeek:     []string{"Tuesday", "Wednesday"},
+					DaysOfWeek:     []string{"Tuesday"},
 					Interval:       3,
 					RecurrenceType: "relativeMonthly",
 				},
@@ -254,12 +254,12 @@ func TestRecurrenceGeneration(t *testing.T) {
 		},
 		{
 			name:       "Relative Yearly NoEnd",
-			recurrence: "every other year on the last Monday, Tuesday, and Wednesday of March, beginning in 2027",
+			recurrence: "every other year on the last Monday of March, beginning in 2027",
 			expected: Recurrence{
 				Pattern: RecurrencePattern{
 					Index:          "last",
 					Month:          3,
-					DaysOfWeek:     []string{"Monday", "Tuesday", "Wednesday"},
+					DaysOfWeek:     []string{"Monday"},
 					Interval:       2,
 					RecurrenceType: "relativeYearly",
 				},

--- a/outlook/calendar/pkg/recurrence/recurrence_test.go
+++ b/outlook/calendar/pkg/recurrence/recurrence_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO - test these for real with Outlook
 func TestRecurrenceGeneration(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -151,7 +152,159 @@ func TestRecurrenceGeneration(t *testing.T) {
 				},
 			},
 		},
-		// TODO - add more tests
+		{
+			name:       "Relative Monthly NoEnd",
+			recurrence: "every month on the first Thursday, beginning 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "first",
+					DaysOfWeek:     []string{"Thursday"},
+					Interval:       1,
+					RecurrenceType: "relativeMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Relative Monthly EndDate",
+			recurrence: "every two months on the last Friday, from 2/2/27 to 7/7/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "last",
+					DaysOfWeek:     []string{"Friday"},
+					Interval:       2,
+					RecurrenceType: "relativeMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					EndDate:        "2027-07-07",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Relative Monthly Numbered",
+			recurrence: "every three months on the third Tuesday and Wednesday, for 18 events, starting 3/3/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "third",
+					DaysOfWeek:     []string{"Tuesday", "Wednesday"},
+					Interval:       3,
+					RecurrenceType: "relativeMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-03-03",
+					NumberOfOccurrences: 18,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
+		{
+			name:       "Absolute Yearly NoEnd",
+			recurrence: "every other year on April 1st, beginning in 2027",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Month:          4,
+					DayOfMonth:     1,
+					Interval:       2,
+					RecurrenceType: "absoluteYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-04-01",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Absolute Yearly EndDate",
+			recurrence: "every year on April 1st, from 2027 to 2030",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Month:          4,
+					DayOfMonth:     1,
+					Interval:       1,
+					RecurrenceType: "absoluteYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-04-01",
+					EndDate:        "2030-04-01",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Absolute Yearly Numbered",
+			recurrence: "every five years on May 4th, 9 times, starting in 2027",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Month:          5,
+					DayOfMonth:     4,
+					Interval:       5,
+					RecurrenceType: "absoluteYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-05-04",
+					NumberOfOccurrences: 9,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
+		{
+			name:       "Relative Yearly NoEnd",
+			recurrence: "every other year on the last Monday, Tuesday, and Wednesday of March, beginning in 2027",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "last",
+					Month:          3,
+					DaysOfWeek:     []string{"Monday", "Tuesday", "Wednesday"},
+					Interval:       2,
+					RecurrenceType: "relativeYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-03-29",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Relative Yearly EndDate",
+			recurrence: "every year on the first Friday of March, from 2027 to 2039",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "first",
+					Month:          3,
+					DaysOfWeek:     []string{"Friday"},
+					Interval:       1,
+					RecurrenceType: "relativeYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-03-01",
+					EndDate:        "2039-12-31",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Relative Yearly Numbered",
+			recurrence: "every third year on the fourth Thursday of May, for 10 occurrences, starting in 2027",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Index:          "fourth",
+					Month:          5,
+					DaysOfWeek:     []string{"Thursday"},
+					Interval:       3,
+					RecurrenceType: "relativeYearly",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-05-27",
+					NumberOfOccurrences: 10,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/outlook/calendar/pkg/recurrence/recurrence_test.go
+++ b/outlook/calendar/pkg/recurrence/recurrence_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO - test these for real with Outlook
 func TestRecurrenceGeneration(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/outlook/calendar/pkg/recurrence/recurrence_test.go
+++ b/outlook/calendar/pkg/recurrence/recurrence_test.go
@@ -1,0 +1,164 @@
+package recurrence
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecurrenceGeneration(t *testing.T) {
+	tests := []struct {
+		name       string
+		recurrence string
+		expected   Recurrence
+	}{
+		{
+			name:       "Daily NoEnd",
+			recurrence: "every 3 days, beginning 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Interval:       3,
+					RecurrenceType: "daily",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Daily EndDate",
+			recurrence: "every 4 days, from 2/2/27 to 4/4/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Interval:       4,
+					RecurrenceType: "daily",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					EndDate:        "2027-04-04",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Daily Numbered",
+			recurrence: "every 5 days, for 10 occurrences, starting 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					Interval:       5,
+					RecurrenceType: "daily",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-02-02",
+					NumberOfOccurrences: 10,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
+		{
+			name:       "Weekly NoEnd",
+			recurrence: "every other week on Monday, beginning 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DaysOfWeek:     []string{"Monday"},
+					Interval:       2,
+					RecurrenceType: "weekly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Weekly EndDate",
+			recurrence: "every week on Tuesday, from 2/2/27 to 4/4/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DaysOfWeek:     []string{"Tuesday"},
+					RecurrenceType: "weekly",
+					Interval:       1,
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					EndDate:        "2027-04-04",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Weekly Numbered",
+			recurrence: "every three weeks on Wednesday, Thursday, and Friday, 5 times, starting 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DaysOfWeek:     []string{"Wednesday", "Thursday", "Friday"},
+					Interval:       3,
+					RecurrenceType: "weekly",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-02-02",
+					NumberOfOccurrences: 5,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
+		{
+			name:       "Absolute Monthly NoEnd",
+			recurrence: "every month on the 15th, beginning 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DayOfMonth:     15,
+					Interval:       1,
+					RecurrenceType: "absoluteMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					RecurrenceType: "noEnd",
+				},
+			},
+		},
+		{
+			name:       "Absolute Monthly EndDate",
+			recurrence: "every other month on the 15th, from 2/2/27 to 4/4/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DayOfMonth:     15,
+					Interval:       2,
+					RecurrenceType: "absoluteMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:      "2027-02-02",
+					EndDate:        "2027-04-04",
+					RecurrenceType: "endDate",
+				},
+			},
+		},
+		{
+			name:       "Absolute Monthly Numbered",
+			recurrence: "every three months on the 16th, 9 times, starting 2/2/27",
+			expected: Recurrence{
+				Pattern: RecurrencePattern{
+					DayOfMonth:     16,
+					Interval:       3,
+					RecurrenceType: "absoluteMonthly",
+				},
+				Range: RecurrenceRange{
+					StartDate:           "2027-02-02",
+					NumberOfOccurrences: 9,
+					RecurrenceType:      "numbered",
+				},
+			},
+		},
+		// TODO - add more tests
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Generate(context.Background(), tt.recurrence)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -47,7 +47,7 @@ Param: owner_type: The type of the owner of the calendar or group. Possible valu
 ---
 Name: Create Event
 Description: Create a new event.
-Share Context: Outlook Calendar Context
+Share Context: Outlook Calendar Context, Recurrence Context
 Credential: ./credential
 Share Tools: List Calendars
 Param: subject: (Required) The title of the event.
@@ -55,9 +55,9 @@ Param: location: (Required) The location of the event.
 Param: body: (Required) The details of the event.
 Param: attendees: (Required) A comma-separated list of the email addresses of people to invite to the event.
 Param: is_online: (Required) (boolean) Whether the event is online (true) or in person (false).
-Param: start: (Required) The start date and time of the event, in RFC 3339 format.
-Param: end: (Required) The end date and time of the event, in RFC 3339 format.
-Param: recurrence: (Optional) If the meeting should recur, describe in plain English how often it should occur (daily, weekly, monthly, yearly) and during which date range (first and last occurence) or how many total times the event should occur.
+Param: start: (Required) The start time of the event, in RFC 3339 format.
+Param: end: (Required) The end time of the event, in RFC 3339 format. When scheduling a recurring event, this should be the end time of the first event in the series.
+Param: recurrence: (Optional) If the meeting should recur, describe in plain English how often it should occur (daily, weekly, monthly, yearly) and during which date range (first and last occurrence) or how many total times the event should occur. ALWAYS include the date of the first occurrence, and optionally the date of the last occurrence.
 Param: calendar_id: The unique ID of the calendar or group to add the event to. If unset, adds the event to the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.
 
@@ -130,6 +130,49 @@ Do not output calendar IDs or event IDs because they are not helpful for the use
 You don't know the user's timezone. If they ask you to create or modify events, get clarification about their timezone and use it. If creating a date/time in the UTC timezone, it must end with 'Z' to properly denote it's for UTC.
 
 ## End of instructions for using the Microsoft Outlook Calendar tools
+
+---
+Name: Recurrence Context
+Type: context
+
+#!sys.echo
+
+## Instructions for scheduling recurring meetings in Outlook Calendar
+
+When scheduling a recurring meeting in Outlook Calendar, include as much information as you can about when it should occur.
+Always include the date of the first occurrence of the event. Here are some examples of how to describe recurrence well:
+
+Daily:
+- "every 3 days, beginning 2/2/27"
+- "every 4 days, from 2/2/27 to 4/4/27"
+- "every 5 days, for 10 occurrences, starting 2/2/27"
+
+Weekly:
+- "every other week on Monday, beginning 2/2/27"
+- "every week on Tuesday, from 2/2/27 to 4/4/27"
+- "every three weeks on Wednesday, Thursday, and Friday, 5 times, starting 2/2/27"
+
+Monthly:
+- "every month on the 15th, beginning 2/15/27"
+- "every other month on the 15th, from 2/15/27 to 6/16/27"
+- "every three months on the 16th, 9 times, starting 2/16/27"
+- "every month on the first Thursday, beginning 2/2/27"
+- "every two months on the last Friday, from 2/2/27 to 7/7/28"
+- "every three months on the third Tuesday, for 18 events, starting 3/3/27"
+
+Yearly:
+- "every other year on April 1st, beginning in 2027"
+- "every year on April 1st, from 2027 to 2030"
+- "every five years on May 4th, 9 times, starting in 2027"
+- "every other year on the last Monday of March, beginning in 2027"
+- "every year on the first Friday of March, from 2027 to 2039"
+- "every third year on the fourth Thursday of May, for 10 occurrences, starting in 2027"
+
+When setting the `end` parameter, it should be the date and time of the end of the very first event in the series.
+In most circumstances, this event will not span multiple days. Ask for confirmation from the user before creating a single
+event that spans multiple days.
+
+## End of instructions for scheduling recurring meetings in Outlook Calendar
 
 ---
 !metadata:*:category

--- a/outlook/calendar/tool.gpt
+++ b/outlook/calendar/tool.gpt
@@ -57,6 +57,7 @@ Param: attendees: (Required) A comma-separated list of the email addresses of pe
 Param: is_online: (Required) (boolean) Whether the event is online (true) or in person (false).
 Param: start: (Required) The start date and time of the event, in RFC 3339 format.
 Param: end: (Required) The end date and time of the event, in RFC 3339 format.
+Param: recurrence: (Optional) If the meeting should recur, describe in plain English how often it should occur (daily, weekly, monthly, yearly) and during which date range (first and last occurence) or how many total times the event should occur.
 Param: calendar_id: The unique ID of the calendar or group to add the event to. If unset, adds the event to the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.
 


### PR DESCRIPTION
Recurring meetings in the Outlook Calendar API are fairly complicated. To help handle this, I implemented an internal tool call to turn a plain English description of the recurrence logic into the proper fields required by the API. I have tested this thoroughly and it works well.