### PR TITLE
fix: speed up slack requests by caching user names

### DIFF
--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#b42172c6b4f89b6bda6e7d422c2e486dcee1e99a",
-        "@slack/web-api": "^7.3.2"
+        "@slack/web-api": "^7.3.2",
+        "async-mutex": "^0.5.0"
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
@@ -117,6 +118,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -414,6 +424,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "license": "0BSD"
     },
     "node_modules/undici-types": {
       "version": "6.13.0",

--- a/slack/package.json
+++ b/slack/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "dependencies": {
     "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#b42172c6b4f89b6bda6e7d422c2e486dcee1e99a",
-    "@slack/web-api": "^7.3.2"
+    "@slack/web-api": "^7.3.2",
+    "async-mutex": "^0.5.0"
   }
 }


### PR DESCRIPTION
Cache user names to speed up requests to get channel history from slack.

