### PR TITLE
feat: (knowledge) mupdf merge pages by default within tokenlimit

### DIFF
--- a/knowledge/go.mod
+++ b/knowledge/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/ncruces/go-sqlite3 v0.19.0
 	github.com/pgvector/pgvector-go v0.2.2
 	github.com/philippgille/chromem-go v0.6.1-0.20240811154507-a1944285b284
+	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/files v1.0.1
@@ -150,7 +151,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/richardlehane/mscfb v1.0.3 // indirect

--- a/knowledge/pkg/datastore/documentloader/mupdf.go
+++ b/knowledge/pkg/datastore/documentloader/mupdf.go
@@ -28,16 +28,18 @@ func init() {
 	}
 
 	MuPDFGetter = func(config any) (LoaderFunc, error) {
-		var pdfConfig mupdf.PDFOptions
+		var opts []func(*mupdf.PDFOptions)
 		if config != nil {
+			var pdfConfig mupdf.PDFOptions
 			slog.Debug("PDF custom config", "config", config)
 			if err := mapstructure.Decode(config, &pdfConfig); err != nil {
 				return nil, fmt.Errorf("failed to decode PDF document loader configuration: %w", err)
 			}
 			slog.Debug("PDF custom config (decoded)", "pdfConfig", pdfConfig)
+			opts = append(opts, mupdf.WithConfig(pdfConfig))
 		}
 		return func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
-			r, err := mupdf.NewPDF(reader, mupdf.WithConfig(pdfConfig))
+			r, err := mupdf.NewPDF(reader, opts...)
 			if err != nil {
 				slog.Error("Failed to create PDF loader", "error", err)
 				return nil, err

--- a/knowledge/pkg/datastore/documentloader/pdf/mupdf/pdf.go
+++ b/knowledge/pkg/datastore/documentloader/pdf/mupdf/pdf.go
@@ -185,7 +185,12 @@ func (l *PDF) Load(ctx context.Context) ([]vs.Document, error) {
 		})
 	}
 
-	return l.mergePages(docs, docTokenCounts, numPages), g.Wait()
+	err := g.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return l.mergePages(docs, docTokenCounts, numPages), nil
 }
 
 func (l *PDF) mergePages(docs []vs.Document, docTokenCounts []int, totalPages int) []vs.Document {


### PR DESCRIPTION
### Example

Command + Logs
```bash
$ knowledge load --loader=mupdf .local/testdata/files/2023q4-alphabet-earnings-release.pdf -
2024/10/30 16:25:06 DEBUG Merged PDF pages totalPages=11 mergedPages=4
```

Output/Results:
```json
{
  "metadata": {
    "source": ".local/testdata/files/2023q4-alphabet-earnings-release.pdf",
    "totalPages": 11
  },
  "documents": [
    {
      "metadata": {
        "pages": "1-2",
        "tokenCount": 1107
      },
      "content": "Alphabet Announces Fourth Quarter and Fiscal Year 2023 Results\n\nMOUNTAIN VIEW, Calif. – January 30, 2024 – Alphabet Inc. (NASDAQ: GOOG, GOOGL) today announced\n\nfinancial results for the quarter and fiscal year ended December 31, 2023.\n\nSundar Pichai, CEO, said: “We are pleased with the ongoing strength in Search and the growing contribution from\n\nYouTube and Cloud. Each of these is already benefiting from our AI investments and innovation. As we enter the\n\nGemini era, the best is yet to come.”\n\nRuth Porat, President and Chief Investment Officer; CFO said: “We ended 2023 with very strong fourth quarter\n\nfinancial results, with Q4 consolidated revenues of $86 billion, up 13% year over year. We remain committed to our\n\nwork to durably re-engineer our cost base as we invest to support our growth opportunities.”\n\n**Q4 2023 Financial Highlights**\n\nThe following table summarizes our consolidated financial results for the quarters and years ended December 31,\n\n2022 and 2023 (in millions, except for per share information and percentages).\n\n**Quarter Ended**\n\n**December 31,**\n\n**Year Ended**\n\n**December 31,**\n\n**2022**\n\n**2023**\n\n**2022**\n\n**2023**\n\n**(unaudited)**\n\n**(unaudited)**\n\nRevenues\n\n$ 76,048\n\n$ 86,310\n\n$ 282,836\n\n$ 307,394\n\nChange in revenues year over year\n\n1 %\n\n13 %\n\n10 %\n\n9 %\n\nChange in constant currency revenues year over year(1)\n\n7 %\n\n13 %\n\n14 %\n\n10 %\n\nOperating income\n\n$ 18,160\n\n$ 23,697\n\n$ 74,842\n\n$ 84,293\n\nOperating margin\n\n24 %\n\n27 %\n\n26 %\n\n27 %\n\nOther income (expense), net\n\n$\n\n(1,013)\n\n$\n\n715\n\n$\n\n(3,514)\n\n$\n\n1,424\n\nNet income\n\n$ 13,624\n\n$ 20,687\n\n$ 59,972\n\n$ 73,795\n\nDiluted EPS\n\n$\n\n1.05\n\n$\n\n1.64\n\n$\n\n4.56\n\n$\n\n5.80\n\n(1)\n\nNon-GAAP measure. See the table captioned “Reconciliation from GAAP revenues to non-GAAP constant currency\n\nrevenues and GAAP percentage change in revenues to non-GAAP percentage change in constant currency revenues” for\n\nmore details.\n**Q4 2023 Supplemental Information** (in millions, except for number of employees; unaudited)\n\n***Revenues, Traffic Acquisition Costs (TAC), and Number of Employees***\n\n**Quarter Ended December 31,**\n\n**2022**\n\n**2023**\n\nGoogle Search \u0026amp; other\n\n$\n\n42,604 $\n\n48,020\n\nYouTube ads\n\n7,963\n\n9,200\n\nGoogle Network\n\n8,475\n\n8,297\n\nGoogle advertising\n\n59,042\n\n65,517\n\nGoogle subscriptions, platforms, and devices(1)\n\n8,796\n\n10,794\n\nGoogle Services total\n\n67,838\n\n76,311\n\nGoogle Cloud\n\n7,315\n\n9,192\n\nOther Bets\n\n226\n\n657\n\nHedging gains (losses)\n\n669\n\n150\n\nTotal revenues\n\n$\n\n76,048 $\n\n86,310\n\nTotal TAC\n\n$\n\n12,925 $\n\n13,986\n\nNumber of employees\n\n190,234\n\n182,502\n\n(1)\n\nFormerly “Google other.”\n\n***Segment Operating Results***\n\n**Quarter Ended December 31,**\n\n**2022**\n\n**2023**\n\nOperating income (loss):\n\nGoogle Services\n\n$\n\n20,222 $\n\n26,730\n\nGoogle Cloud\n\n(186)\n\n864\n\nOther Bets\n\n(1,237)\n\n(863)\n\nAlphabet-level activities(1)\n\n(639)\n\n(3,034)\n\nTotal income from operations\n\n$\n\n18,160 $\n\n23,697\n\n(1)\n\nFormerly “corporate costs, unallocated.” In addition to the costs included in Alphabet-level activities, hedging gains (losses)\n\nrelated to revenue were $669 million and $150 million for the three months ended December 31, 2022 and 2023,\n\nrespectively. For the quarter ended December 31, 2023, Alphabet-level activities included charges related to the reduction\n\nin force and our office space optimization efforts totaling $1.2 billion and $62 million in accelerated rent and accelerated\n\ndepreciation.\n\n**Additional Information Relating to the Quarter Ended December 31, 2023** (unaudited)\n\n***Reductions in Our Workforce and Office Space***\n\nIn January 2023, we announced a reduction of our workforce, and as a result we recorded employee severance and\n\nrelated charges of $2.1 billion for the twelve months ended December 31, 2023. In addition, we are taking actions\n\nto optimize our global office space. As a result, exit charges recorded during the three and twelve months ended\n\nDecember 31, 2023, were $1.2 billion and $1.8 billion, respectively. In addition to these exit charges, for the three\n\nand twelve months ended December 31, 2023, we incurred $62 million and $269 million, respectively, in\n\naccelerated rent and accelerated depreciation.\n\n2"
    },
    {
      "metadata": {
        "pages": "3-5",
        "tokenCount": 1928
      },
      "content": "Severance and office space exit charges are included within our consolidated statements of income as follows (in\n\nmillions):\n\n**Quarter Ended December 31, 2023**\n\n**Year Ended December 31, 2023**\n\n**Severance**\n\n**and Related**\n\n**Office Space**\n\n**Total**\n\n**Severance**\n\n**and Related**\n\n**Office Space**\n\n**Total**\n\nCost of revenues\n\n$\n\n2 $\n\n235 $\n\n237 $\n\n479 $\n\n481 $\n\n960\n\nResearch and development\n\n1\n\n602\n\n603\n\n848\n\n870\n\n1,718\n\nSales and marketing\n\n3\n\n198\n\n201\n\n497\n\n257\n\n754\n\nGeneral and administrative\n\n1\n\n161\n\n162\n\n264\n\n237\n\n501\n\nTotal charges\n\n$\n\n7 $\n\n1,196 $\n\n1,203 $\n\n2,088 $\n\n1,845 $\n\n3,933\n\nFor segment reporting, the substantial majority of these charges are included within Alphabet-level activities in our\n\nsegment results.\n\n***Change in Useful Lives of Our Server and Network Equipment***\n\nIn January 2023, we completed an assessment of the useful lives of our servers and network equipment and\n\nadjusted the estimated useful life of our servers from four years to six years and the estimated useful life of certain\n\nnetwork equipment from five years to six years. This change in accounting estimate was effective beginning in fiscal\n\nyear 2023, and the effect was a reduction in depreciation expense of $983 million and $3.9 billion and an increase\n\nin net income of $765 million and $3.0 billion, or $0.06 and $0.24 per basic and $0.06 and $0.24 per diluted share\n\nfor the three and twelve months ended December 31, 2023, respectively.\n\n**Webcast and Conference Call Information**\n\nA live audio webcast of our fourth quarter 2023 earnings release call will be available on YouTube at https://\n\nwww.youtube.com/watch?v=b4alwdVvn4Q. The call begins today at 1:30 PM (PT) / 4:30 PM (ET). This press\n\nrelease, including the reconciliations of certain non-GAAP measures to their nearest comparable GAAP measures,\n\nis also available at http://abc.xyz/investor.\n\nWe also provide announcements regarding our financial performance, including SEC filings, investor events, press\n\nand earnings releases, and blogs, on our investor relations website (http://abc.xyz/investor).\n\nWe also share Google news and product updates on Google’s Keyword blog at https://www.blog.google/, which may\n\nbe of interest or material to our investors.\n\n**Forward-Looking Statements**\n\nThis press release may contain forward-looking statements that involve risks and uncertainties. Actual results may\n\ndiffer materially from the results predicted, and reported results should not be considered as an indication of future\n\nperformance. The potential risks and uncertainties that could cause actual results to differ from the results predicted\n\ninclude, among others, those risks and uncertainties included under the captions “Risk Factors” and “Management’s\n\nDiscussion and Analysis of Financial Condition and Results of Operations” in our Annual Report on Form 10-K for\n\nthe year ended December 31, 2022 and our most recent Quarterly Report on Form 10-Q for the quarter ended\n\nSeptember 30, 2023, which are on file with the SEC and are available on our investor relations website at http://\n\nabc.xyz/investor and on the SEC website at www.sec.gov. Additional information will also be set forth in our Annual\n\nReport on Form 10-K for the year ended December 31, 2023, and may be set forth in other reports and filings we\n\nmake with the SEC. All information provided in this release and in the attachments is as of January 30, 2024. Undue\n\nreliance should not be placed on the forward-looking statements in this press release, which are based on\n\ninformation available to us on the date hereof. We undertake no duty to update this information unless required by\n\nlaw.\n\n**About Non-GAAP Financial Measures**\n\nTo supplement our consolidated financial statements, which are prepared and presented in accordance with GAAP,\n\nwe use the following non-GAAP financial measures: free cash flow; constant currency revenues; and percentage\n\nchange in constant currency revenues. The presentation of this financial information is not intended to be\n\nconsidered in isolation or as a substitute for, or superior to, the financial information prepared and presented in\n\naccordance with GAAP.\n\nWe use these non-GAAP financial measures for financial and operational decision-making and as a means to\n\nevaluate period-to-period comparisons. We believe that these non-GAAP financial measures provide meaningful\n\n3\nsupplemental information regarding our performance and liquidity by excluding certain items that may not be\n\nindicative of our recurring core business operating results, such as our revenues excluding the effect of foreign\n\nexchange rate movements and hedging activities, which are recognized at the consolidated level. We believe that\n\nboth management and investors benefit from referring to these non-GAAP financial measures in assessing our\n\nperformance and when planning, forecasting, and analyzing future periods. These non-GAAP financial measures\n\nalso facilitate management’s internal comparisons to our historical performance and liquidity as well as comparisons\n\nto our competitors’ operating results. We believe these non-GAAP financial measures are useful to investors both\n\nbecause (1) they allow for greater transparency with respect to key metrics used by management in its financial and\n\noperational decision-making and (2) they are used by our institutional investors and the analyst community to help\n\nthem analyze the health of our business.\n\nThere are a number of limitations related to the use of non-GAAP financial measures. We compensate for these\n\nlimitations by providing specific information regarding the GAAP amounts excluded from these non-GAAP financial\n\nmeasures and evaluating these non-GAAP financial measures together with their relevant financial measures in\n\naccordance with GAAP.\n\nFor more information on these non-GAAP financial measures, please see the tables captioned “Reconciliation from\n\nGAAP net cash provided by operating activities to non-GAAP free cash flow” and “Reconciliation from GAAP\n\nrevenues to non-GAAP constant currency revenues and GAAP percentage change in revenues to non-GAAP\n\npercentage change in constant currency revenues” included at the end of this release.\n\n**Contact**\n\nInvestor relations\n\nMedia\n\ninvestor-relations@abc.xyz press@abc.xyz\n\n4\n**Alphabet Inc.**\n\n**CONSOLIDATED BALANCE SHEETS**\n\n(In millions, except par value per share amounts)\n\n**As of December 31,**\n\n**2022**\n\n**2023**\n\n**(unaudited)**\n\n**Assets**\n\nCurrent assets:\n\nCash and cash equivalents\n\n$\n\n21,879\n\n$\n\n24,048\n\nMarketable securities\n\n91,883\n\n86,868\n\nTotal cash, cash equivalents, and marketable securities\n\n113,762\n\n110,916\n\nAccounts receivable, net\n\n40,258\n\n47,964\n\nOther current assets\n\n10,775\n\n12,650\n\nTotal current assets\n\n164,795\n\n171,530\n\nNon-marketable securities\n\n30,492\n\n31,008\n\nDeferred income taxes\n\n5,261\n\n12,169\n\nProperty and equipment, net\n\n112,668\n\n134,345\n\nOperating lease assets\n\n14,381\n\n14,091\n\nGoodwill\n\n28,960\n\n29,198\n\nOther non-current assets\n\n8,707\n\n10,051\n\nTotal assets\n\n$\n\n365,264\n\n$\n\n402,392\n\n**Liabilities and Stockholders’ Equity**\n\nCurrent liabilities:\n\nAccounts payable\n\n$\n\n5,128\n\n$\n\n7,493\n\nAccrued compensation and benefits\n\n14,028\n\n15,140\n\nAccrued expenses and other current liabilities\n\n37,866\n\n46,168\n\nAccrued revenue share\n\n8,370\n\n8,876\n\nDeferred revenue\n\n3,908\n\n4,137\n\nTotal current liabilities\n\n69,300\n\n81,814\n\nLong-term debt\n\n14,701\n\n13,253\n\nDeferred revenue, non-current\n\n599\n\n911\n\nIncome taxes payable, non-current\n\n9,258\n\n8,474\n\nDeferred income taxes\n\n514\n\n485\n\nOperating lease liabilities\n\n12,501\n\n12,460\n\nOther long-term liabilities\n\n2,247\n\n1,616\n\nTotal liabilities\n\n109,120\n\n119,013\n\nCommitments and contingencies\n\nStockholders’ equity:\n\nPreferred stock, $0.001 par value per share, 100 shares authorized; no shares\n\nissued and outstanding\n\n0\n\n0\n\nClass A, Class B, and Class C stock and additional paid-in capital, $0.001 par\n\nvalue per share: 300,000 shares authorized (Class A 180,000, Class B 60,000,\n\nClass C 60,000); 12,849 (Class A 5,964, Class B 883, Class C 6,002) and 12,460\n\n(Class A 5,899, Class B 870, Class C 5,691) shares issued and outstanding\n\n68,184\n\n76,534\n\nAccumulated other comprehensive income (loss)\n\n(7,603)\n\n(4,402)\n\nRetained earnings\n\n195,563\n\n211,247\n\nTotal stockholders’ equity\n\n256,144\n\n283,379\n\nTotal liabilities and stockholders’ equity\n\n$\n\n365,264\n\n$\n\n402,392\n\n5"
    },
    {
      "metadata": {
        "pages": "6-8",
        "tokenCount": 1961
      },
      "content": "**Alphabet Inc.**\n\n**CONSOLIDATED STATEMENTS OF INCOME**\n\n(In millions, except per share amounts)\n\n**Quarter Ended December 31,**\n\n**Year Ended December 31,**\n\n**2022**\n\n**2023**\n\n**2022**\n\n**2023**\n\n**(unaudited)**\n\n**(unaudited)**\n\nRevenues\n\n$\n\n76,048\n\n$\n\n86,310\n\n$\n\n282,836\n\n$\n\n307,394\n\nCosts and expenses:\n\nCost of revenues\n\n35,342\n\n37,575\n\n126,203\n\n133,332\n\nResearch and development\n\n10,267\n\n12,113\n\n39,500\n\n45,427\n\nSales and marketing\n\n7,183\n\n7,719\n\n26,567\n\n27,917\n\nGeneral and administrative\n\n5,096\n\n5,206\n\n15,724\n\n16,425\n\nTotal costs and expenses\n\n57,888\n\n62,613\n\n207,994\n\n223,101\n\nIncome from operations\n\n18,160\n\n23,697\n\n74,842\n\n84,293\n\nOther income (expense), net\n\n(1,013)\n\n715\n\n(3,514)\n\n1,424\n\nIncome before income taxes\n\n17,147\n\n24,412\n\n71,328\n\n85,717\n\nProvision for income taxes\n\n3,523\n\n3,725\n\n11,356\n\n11,922\n\nNet income\n\n$\n\n13,624\n\n$\n\n20,687\n\n$\n\n59,972\n\n$\n\n73,795\n\nBasic earnings per share of Class A, Class B, and Class C\n\nstock\n\n$\n\n1.06\n\n$\n\n1.66\n\n$\n\n4.59\n\n$\n\n5.84\n\nDiluted earnings per share of Class A, Class B, and Class\n\nC stock\n\n$\n\n1.05\n\n$\n\n1.64\n\n$\n\n4.56\n\n$\n\n5.80\n\nNumber of shares used in basic earnings per share\n\ncalculation\n\n12,897\n\n12,488\n\n13,063\n\n12,630\n\nNumber of shares used in diluted earnings per share\n\ncalculation\n\n12,947\n\n12,602\n\n13,159\n\n12,722\n\n6\n**Alphabet Inc.**\n\n**CONSOLIDATED STATEMENTS OF CASH FLOWS**\n\n(In millions)\n\n**Quarter Ended December 31,**\n\n**Year Ended December 31,**\n\n**2022**\n\n**2023**\n\n**2022**\n\n**2023**\n\n**(unaudited)**\n\n**(unaudited)**\n\n**Operating activities**\n\nNet income\n\n$\n\n13,624\n\n$\n\n20,687\n\n$\n\n59,972\n\n$\n\n73,795\n\nAdjustments:\n\nDepreciation of property and equipment\n\n3,602\n\n3,316\n\n13,475\n\n11,946\n\nStock-based compensation expense\n\n5,100\n\n5,659\n\n19,362\n\n22,460\n\nDeferred income taxes\n\n(1,924)\n\n(1,670)\n\n(8,081)\n\n(7,763)\n\n(Gain) loss on debt and equity securities, net\n\n1,663\n\n(471)\n\n5,519\n\n823\n\nOther\n\n1,260\n\n1,665\n\n3,483\n\n4,330\n\nChanges in assets and liabilities, net of effects of\n\nacquisitions:\n\nAccounts receivable, net\n\n(4,615)\n\n(6,518)\n\n(2,317)\n\n(7,833)\n\nIncome taxes, net\n\n1,446\n\n(9,869)\n\n584\n\n523\n\nOther assets\n\n(778)\n\n740\n\n(5,046)\n\n(2,143)\n\nAccounts payable\n\n(28)\n\n427\n\n707\n\n664\n\nAccrued expenses and other liabilities\n\n3,424\n\n4,317\n\n3,915\n\n3,937\n\nAccrued revenue share\n\n577\n\n797\n\n(445)\n\n482\n\nDeferred revenue\n\n263\n\n(165)\n\n367\n\n525\n\nNet cash provided by operating activities\n\n23,614\n\n18,915\n\n91,495\n\n101,746\n\n**Investing activities**\n\nPurchases of property and equipment\n\n(7,595)\n\n(11,019)\n\n(31,485)\n\n(32,251)\n\nPurchases of marketable securities\n\n(11,621)\n\n(28,436)\n\n(78,874)\n\n(77,858)\n\nMaturities and sales of marketable securities\n\n13,735\n\n34,030\n\n97,822\n\n86,672\n\nPurchases of non-marketable securities\n\n(903)\n\n(851)\n\n(2,531)\n\n(3,027)\n\nMaturities and sales of non-marketable securities\n\n19\n\n204\n\n150\n\n947\n\nAcquisitions, net of cash acquired, and purchases of\n\nintangible assets\n\n(84)\n\n(29)\n\n(6,969)\n\n(495)\n\nOther investing activities\n\n222\n\n(66)\n\n1,589\n\n(1,051)\n\nNet cash used in investing activities\n\n(6,227)\n\n(6,167)\n\n(20,298)\n\n(27,063)\n\n**Financing activities**\n\nNet payments related to stock-based award activities\n\n(2,079)\n\n(2,680)\n\n(9,300)\n\n(9,837)\n\nRepurchases of stock\n\n(15,407)\n\n(16,191)\n\n(59,296)\n\n(61,504)\n\nProceeds from issuance of debt, net of costs\n\n8,550\n\n1,492\n\n52,872\n\n10,790\n\nRepayments of debt\n\n(8,718)\n\n(1,929)\n\n(54,068)\n\n(11,550)\n\nProceeds from sale of interest in consolidated entities,\n\nnet\n\n25\n\n0\n\n35\n\n8\n\nNet cash used in financing activities\n\n(17,629)\n\n(19,308)\n\n(69,757)\n\n(72,093)\n\nEffect of exchange rate changes on cash and cash\n\nequivalents\n\n137\n\n(94)\n\n(506)\n\n(421)\n\n**Net increase (decrease) in cash and cash**\n\n**equivalents**\n\n(105)\n\n(6,654)\n\n934\n\n2,169\n\nCash and cash equivalents at beginning of period\n\n21,984\n\n30,702\n\n20,945\n\n21,879\n\n**Cash and cash equivalents at end of period**\n\n$\n\n21,879\n\n$\n\n24,048\n\n$\n\n21,879\n\n$\n\n24,048\n\n7\n**Segment Results**\n\nThe following table presents our segment revenues and operating income (loss) (in millions; unaudited):\n\n**Quarter Ended December 31,**\n\n**2022**\n\n**2023**\n\nRevenues:\n\nGoogle Services\n\n$\n\n67,838 $\n\n76,311\n\nGoogle Cloud\n\n7,315\n\n9,192\n\nOther Bets\n\n226\n\n657\n\nHedging gains (losses)\n\n669\n\n150\n\nTotal revenues\n\n$\n\n76,048 $\n\n86,310\n\nOperating income (loss):\n\nGoogle Services\n\n$\n\n20,222 $\n\n26,730\n\nGoogle Cloud\n\n(186)\n\n864\n\nOther Bets\n\n(1,237)\n\n(863)\n\nAlphabet-level activities\n\n(639)\n\n(3,034)\n\nTotal income from operations\n\n$\n\n18,160 $\n\n23,697\n\nWe report our segment results as Google Services, Google Cloud, and Other Bets:\n\n•\n\nGoogle Services includes products and services such as ads, Android, Chrome, devices, Google Maps,\n\nGoogle Play, Search, and YouTube. Google Services generates revenues primarily from advertising; fees\n\nreceived for consumer subscription-based products such as YouTube TV, YouTube Music and Premium,\n\nand NFL Sunday Ticket; the sale of apps and in-app purchases and devices.\n\n•\n\nGoogle Cloud includes infrastructure and platform services, collaboration tools, and other services for\n\nenterprise customers. Google Cloud generates revenues primarily from consumption-based fees and\n\nsubscriptions received for Google Cloud Platform services, Google Workspace communication and\n\ncollaboration tools, and other enterprise services.\n\n•\n\nOther Bets is a combination of multiple operating segments that are not individually material. Revenues\n\nfrom Other Bets are generated primarily from the sale of healthcare-related services and internet services.\n\nCertain costs are not allocated to our segments because they represent Alphabet-level activities. These costs\n\nprimarily include AI-focused shared R\u0026amp;D activities, including development costs of our general AI models; corporate\n\ninitiatives such as our philanthropic activities; corporate shared costs such as certain finance, human resource, and\n\nlegal costs, including certain fines and settlements. Charges associated with reductions in our workforce and office\n\nspace during 2023 were not allocated to our segments. Additionally, hedging gains (losses) related to revenue are\n\nnot allocated to our segments.\n\n**Other Income (Expense), Net**\n\nThe following table presents our other income (expense), net (in millions; unaudited):\n\n**Quarter Ended December 31,**\n\n**2022**\n\n**2023**\n\nInterest income\n\n$\n\n659 $\n\n1,110\n\nInterest expense\n\n(90)\n\n(69)\n\nForeign currency exchange gain (loss), net\n\n(185)\n\n(449)\n\nGain (loss) on debt securities, net\n\n(176)\n\n(115)\n\nGain (loss) on equity securities, net(1)\n\n(1,487)\n\n586\n\nPerformance fees\n\n193\n\n(45)\n\nIncome (loss) and impairment from equity method investments, net\n\n(31)\n\n(256)\n\nOther\n\n104\n\n(47)\n\nOther income (expense), net\n\n$\n\n(1,013) $\n\n715\n\n(1)\n\nIncludes all gains and losses, unrealized and realized, on equity securities. For Q4 2023, the net effect of the gain on equity\n\nsecurities of $586 million and the $45 million of performance fees related to certain investments increased the provision for\n\n8"
    },
    {
      "metadata": {
        "pages": "9-11",
        "tokenCount": 1892
      },
      "content": "income tax, net income, and diluted EPS by $114 million, $427 million, and $0.03, respectively. Fluctuations in the value of\n\nour investments may be affected by market dynamics and other factors and could significantly contribute to the volatility of\n\nOI\u0026amp;E in future periods.\n\n**Reconciliation from GAAP Net Cash Provided by Operating Activities to Non-GAAP Free Cash Flow** (in\n\nmillions; unaudited)**:**\n\nWe provide non-GAAP free cash flow because it is a liquidity measure that provides useful information to\n\nmanagement and investors about the amount of cash generated by the business that can be used for strategic\n\nopportunities, including investing in our business and acquisitions, and to strengthen our balance sheet.\n\n**Quarter Ended**\n\n**December 31, 2023**\n\n**Net cash provided by operating activities**\n\n$\n\n18,915\n\nLess: purchases of property and equipment\n\n(11,019)\n\n**Free cash flow**\n\n$\n\n7,896\n\n*Free cash flow:* We define free cash flow as net cash provided by operating activities less capital expenditures.\n\n9\n**Reconciliation from GAAP Revenues to Non-GAAP Constant Currency Revenues and GAAP Percentage**\n\n**Change in Revenues to Non-GAAP Percentage Change in Constant Currency Revenues** (in millions, except\n\npercentages; unaudited)**:**\n\nWe provide non-GAAP constant currency revenues (“constant currency revenues”) and non-GAAP percentage change\n\nin constant currency revenues (“percentage change in constant currency revenues”), because they facilitate the\n\ncomparison of current results to historic performance by excluding the effect of foreign exchange rate movements (“FX\n\nEffect”) as well as hedging activities, which are recognized at the consolidated level, as they are not indicative of our\n\ncore operating results.\n\nNon-GAAP constant currency revenues is defined as revenues excluding the effect of foreign exchange rate\n\nmovements and hedging activities and is calculated by translating current period revenues using prior period exchange\n\nrates and excluding any hedging effect recognized in the current period. We calculate the percentage change in\n\nconstant currency revenues by comparing constant currency revenues to the prior year comparable period revenues,\n\nexcluding any hedging effect recognized in the prior period.\n\n***Revenues by Geography***\n\n*Comparison from the Quarter Ended December 31, 2022 to the Quarter Ended December 31, 2023*\n\n**Quarter Ended December 31, 2023**\n\n**% Change from Prior Period**\n\n**Quarter Ended December 31,**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**As**\n\n**Reported**\n\n**Less**\n\n**Hedging**\n\n**Effect**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**2022**\n\n**2023**\n\nUnited States\n\n$\n\n36,982\n\n$\n\n41,995\n\n$\n\n0\n\n$\n\n41,995\n\n14 %\n\n0 %\n\n14 %\n\nEMEA\n\n21,762\n\n25,010\n\n1,105\n\n23,905\n\n15 %\n\n5 %\n\n10 %\n\nAPAC\n\n11,979\n\n13,979\n\n(90)\n\n14,069\n\n17 %\n\n0 %\n\n17 %\n\nOther Americas\n\n4,656\n\n5,176\n\n(75)\n\n5,251\n\n11 %\n\n(2) %\n\n13 %\n\nRevenues, excluding hedging effect\n\n75,379\n\n86,160\n\n940\n\n85,220\n\n14 %\n\n1 %\n\n13 %\n\nHedging gains (losses)\n\n669\n\n150\n\nTotal revenues(1)\n\n$\n\n76,048\n\n$\n\n86,310\n\n$\n\n85,220\n\n13 %\n\n(1) %\n\n1 %\n\n13 %\n\n(1)\n\nTotal constant currency revenues of $85.2 billion for the quarter ended December 31, 2023 increased $9.8 billion compared to $75.4 billion in\n\nrevenues, excluding hedging effect for the quarter ended December 31, 2022.\n\n*Comparison from the Quarter Ended September 30, 2023 to the Quarter Ended December 31, 2023*\n\n**Quarter Ended December 31, 2023**\n\n**% Change from Prior Period**\n\n**Quarter Ended**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**As**\n\n**Reported**\n\n**Less**\n\n**Hedging**\n\n**Effect**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**September**\n\n**30, 2023**\n\n**December**\n\n**31, 2023**\n\nUnited States\n\n$\n\n36,354\n\n$\n\n41,995\n\n$\n\n0\n\n$\n\n41,995\n\n16 %\n\n0 %\n\n16 %\n\nEMEA\n\n22,661\n\n25,010\n\n(508)\n\n25,518\n\n10 %\n\n(3) %\n\n13 %\n\nAPAC\n\n13,126\n\n13,979\n\n(196)\n\n14,175\n\n6 %\n\n(2) %\n\n8 %\n\nOther Americas\n\n4,553\n\n5,176\n\n(151)\n\n5,327\n\n14 %\n\n(3) %\n\n17 %\n\nRevenues, excluding hedging effect\n\n76,694\n\n86,160\n\n(855)\n\n87,015\n\n12 %\n\n(1) %\n\n13 %\n\nHedging gains (losses)\n\n(1)\n\n150\n\nTotal revenues(1)\n\n$\n\n76,693\n\n$\n\n86,310\n\n$\n\n87,015\n\n13 %\n\n1 %\n\n(1) %\n\n13 %\n\n(1)\n\nTotal constant currency revenues of $87.0 billion for the quarter ended December 31, 2023 increased $10.3 billion compared to $76.7 billion in\n\nrevenues, excluding hedging effect for the quarter ended September 30, 2023.\n\n10\n*Comparison from the Year Ended December 31, 2022 to the Year Ended December 31, 2023*\n\n**Year Ended December 31, 2023**\n\n**% Change from Prior Period**\n\n**Year Ended December 31,**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**As**\n\n**Reported**\n\n**Less**\n\n**Hedging**\n\n**Effect**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**2022**\n\n**2023**\n\nUnited States\n\n$\n\n134,814\n\n$\n\n146,286\n\n$\n\n0\n\n$ 146,286\n\n9 %\n\n0 %\n\n9 %\n\nEMEA\n\n82,062\n\n91,038\n\n460\n\n90,578\n\n11 %\n\n1 %\n\n10 %\n\nAPAC\n\n47,024\n\n51,514\n\n(1,759)\n\n53,273\n\n10 %\n\n(3) %\n\n13 %\n\nOther Americas\n\n16,976\n\n18,320\n\n(654)\n\n18,974\n\n8 %\n\n(4) %\n\n12 %\n\nRevenues, excluding hedging effect\n\n280,876\n\n307,158\n\n(1,953)\n\n309,111\n\n9 %\n\n(1) %\n\n10 %\n\nHedging gains (losses)\n\n1,960\n\n236\n\nTotal revenues(1)\n\n$\n\n282,836\n\n$\n\n307,394\n\n$ 309,111\n\n9 %\n\n0 %\n\n(1) %\n\n10 %\n\n(1)\n\nTotal constant currency revenues of $309.1 billion for the year ended December 31, 2023 increased $28.2 billion compared to $280.9 billion in\n\nrevenues, excluding hedging effect for the year ended December 31, 2022.\n\n***Total Revenues — Prior Year Comparative Periods***\n\n*Comparison from the Quarter Ended December 31, 2021 to the Quarter Ended December 31, 2022*\n\n**Quarter Ended December 31, 2022**\n\n**Quarter Ended December**\n\n**31,**\n\n**% Change from Prior Period**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**As**\n\n**Reported**\n\n**Less**\n\n**Hedging**\n\n**Effect**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**2021**\n\n**2022**\n\nRevenues excluding hedging effect\n\n$\n\n75,122\n\n$\n\n75,379\n\n$\n\n(4,733) $\n\n80,112\n\n0 %\n\n(7) %\n\n7 %\n\nHedging gains (losses)\n\n203\n\n669\n\nTotal revenues\n\n$\n\n75,325\n\n$\n\n76,048\n\n$\n\n80,112\n\n1 %\n\n1 %\n\n(7) %\n\n7 %\n\n*Comparison from the Year Ended December 31, 2021 to the Year Ended December 31, 2022*\n\n**Year Ended December 31, 2022**\n\n**% Change from Prior Period**\n\n**Year Ended December 31,**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**As**\n\n**Reported**\n\n**Less**\n\n**Hedging**\n\n**Effect**\n\n**Less FX**\n\n**Effect**\n\n**Constant**\n\n**Currency**\n\n**Revenues**\n\n**2021**\n\n**2022**\n\nRevenues excluding hedging effect\n\n$\n\n257,488\n\n$\n\n280,876\n\n$\n\n(13,324) $ 294,200\n\n9 %\n\n(5) %\n\n14 %\n\nHedging gains (losses)\n\n149\n\n1,960\n\nTotal revenues\n\n$\n\n257,637\n\n$\n\n282,836\n\n$ 294,200\n\n10 %\n\n1 %\n\n(5) %\n\n14 %\n\n11"
    }
  ]
}

```