### PR TITLE
feat: (knowledge) add document index (location in file) to db

### DIFF
--- a/knowledge/pkg/datastore/documentloader/ocr/openai/openai.go
+++ b/knowledge/pkg/datastore/documentloader/ocr/openai/openai.go
@@ -122,8 +122,9 @@ If you identify a specific page type, like book cover, table of contents, etc., 
 
 			docs = append(docs, vs.Document{
 				Metadata: map[string]interface{}{
-					"page":       pageNo,
-					"totalPages": len(images),
+					"page":                    pageNo,
+					"totalPages":              len(images),
+					vs.DocMetadataKeyDocIndex: i,
 				},
 				Content: fmt.Sprintf("%v", result),
 			})

--- a/knowledge/pkg/datastore/documentloader/pdf/gopdf/pdf.go
+++ b/knowledge/pkg/datastore/documentloader/pdf/gopdf/pdf.go
@@ -188,8 +188,9 @@ func (l *PDF) Load(ctx context.Context) ([]vs.Document, error) {
 		doc := vs.Document{
 			Content: strings.TrimSpace(text),
 			Metadata: map[string]any{
-				"page":       page,
-				"totalPages": maxPages,
+				"page":                    page,
+				"totalPages":              maxPages,
+				vs.DocMetadataKeyDocIndex: page - 1,
 			},
 		}
 
@@ -203,14 +204,4 @@ func (l *PDF) Load(ctx context.Context) ([]vs.Document, error) {
 	}
 
 	return docs, nil
-}
-
-// LoadAndSplit loads PDF documents from the provided reader and splits them using the specified text splitter.
-func (l *PDF) LoadAndSplit(ctx context.Context, splitter types.TextSplitter) ([]vs.Document, error) {
-	docs, err := l.Load(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return splitter.SplitDocuments(docs)
 }

--- a/knowledge/pkg/datastore/documentloader/structured/structured.go
+++ b/knowledge/pkg/datastore/documentloader/structured/structured.go
@@ -29,8 +29,14 @@ func (s *Structured) Load(ctx context.Context, reader io.Reader) ([]vs.Document,
 	}
 
 	docs := make([]vs.Document, 0, len(input.Documents))
-	for _, doc := range input.Documents {
+	for i, doc := range input.Documents {
 		maps.Merge(maps.Copy(input.Metadata), doc.Metadata)
+
+		// Set a metadata key for the document index, if not already set.
+		if _, ok := doc.Metadata[vs.DocMetadataKeyDocIndex]; !ok {
+			doc.Metadata[vs.DocMetadataKeyDocIndex] = i
+		}
+
 		docs = append(docs, vs.Document{
 			Content:  doc.Content,
 			Metadata: doc.Metadata,

--- a/knowledge/pkg/datastore/ingest.go
+++ b/knowledge/pkg/datastore/ingest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"github.com/gptscript-ai/knowledge/pkg/log"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore/types"
 
 	"github.com/google/uuid"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/filetypes"
@@ -171,6 +172,9 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 		return nil, nil
 	}
 
+	// Sort documents
+	vs.SortAndEnsureDocIndex(docs)
+
 	// Before adding doc, we need to remove the existing documents for duplicates or old contents
 	statusLog.With("component", "vectorstore").With("action", "remove").Debug("Removing existing documents")
 	where := map[string]string{
@@ -203,6 +207,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 			ID:      docID,
 			FileID:  fileID,
 			Dataset: datasetID,
+			Index:   idx,
 		}
 	}
 

--- a/knowledge/pkg/datastore/textsplitter/adapter.go
+++ b/knowledge/pkg/datastore/textsplitter/adapter.go
@@ -9,6 +9,7 @@ import (
 
 type golcSplitterAdapter struct {
 	golcschema.TextSplitter
+	name string
 }
 
 func (a *golcSplitterAdapter) SplitDocuments(docs []vs.Document) ([]vs.Document, error) {
@@ -16,8 +17,12 @@ func (a *golcSplitterAdapter) SplitDocuments(docs []vs.Document) ([]vs.Document,
 	return types.FromGolcDocs(golcdocs), err
 }
 
-func FromGolc(splitter golcschema.TextSplitter) types.TextSplitter {
-	return &golcSplitterAdapter{splitter}
+func (a *golcSplitterAdapter) Name() string {
+	return a.name
+}
+
+func FromGolc(splitter golcschema.TextSplitter, name string) types.TextSplitter {
+	return &golcSplitterAdapter{splitter, name}
 }
 
 func AsGolc(splitter types.TextSplitter) golcschema.TextSplitter {
@@ -27,7 +32,8 @@ func AsGolc(splitter types.TextSplitter) golcschema.TextSplitter {
 // --- langchaingo ---
 
 type langchainSplitterAdapter struct {
-	lc lcgosplitter.TextSplitter
+	lc   lcgosplitter.TextSplitter
+	name string
 }
 
 func (a *langchainSplitterAdapter) SplitDocuments(docs []vs.Document) ([]vs.Document, error) {
@@ -35,12 +41,12 @@ func (a *langchainSplitterAdapter) SplitDocuments(docs []vs.Document) ([]vs.Docu
 	return types.FromLangchainDocs(lcdocs), err
 }
 
-func FromLangchain(splitter lcgosplitter.TextSplitter) types.TextSplitter {
-	return &langchainSplitterAdapter{splitter}
+func (a *langchainSplitterAdapter) Name() string {
+	return a.name
 }
 
-func LangchainToNative(splitter lcgosplitter.TextSplitter) types.TextSplitter {
-	return FromLangchain(splitter)
+func FromLangchain(splitter lcgosplitter.TextSplitter, name string) types.TextSplitter {
+	return &langchainSplitterAdapter{splitter, name}
 }
 
 func AsLangchain(splitter types.TextSplitter) lcgosplitter.TextSplitter {

--- a/knowledge/pkg/datastore/textsplitter/defaults.go
+++ b/knowledge/pkg/datastore/textsplitter/defaults.go
@@ -9,8 +9,8 @@ func DefaultTextSplitter(filetype string, textSplitterOpts *TextSplitterOpts) ty
 	if textSplitterOpts == nil {
 		textSplitterOpts = z.Pointer(NewTextSplitterOpts())
 	}
-	genericTextSplitter := FromLangchain(NewLcgoTextSplitter(*textSplitterOpts))
-	markdownTextSplitter := FromLangchain(NewLcgoMarkdownSplitter(*textSplitterOpts))
+	genericTextSplitter := FromLangchain(NewLcgoTextSplitter(*textSplitterOpts), "lcgo_text")
+	markdownTextSplitter := FromLangchain(NewLcgoMarkdownSplitter(*textSplitterOpts), "lcgo_markdown")
 
 	switch filetype {
 	case ".md", "text/markdown":

--- a/knowledge/pkg/datastore/textsplitter/textsplitter.go
+++ b/knowledge/pkg/datastore/textsplitter/textsplitter.go
@@ -78,7 +78,7 @@ func GetTextSplitter(name string, config any) (dstypes.TextSplitter, error) {
 			cfg = customCfg
 		}
 		slog.Debug("TextSplitter", "config", cfg)
-		return FromLangchain(NewLcgoTextSplitter(cfg)), nil
+		return FromLangchain(NewLcgoTextSplitter(cfg), "lcgo_text"), nil
 	case "markdown":
 		cfg := NewTextSplitterOpts()
 		if config != nil {
@@ -93,7 +93,7 @@ func GetTextSplitter(name string, config any) (dstypes.TextSplitter, error) {
 			cfg = customCfg
 		}
 		slog.Debug("MarkdownSplitter", "config", cfg)
-		return FromLangchain(NewLcgoMarkdownSplitter(cfg)), nil
+		return FromLangchain(NewLcgoMarkdownSplitter(cfg), "lcgo_markdown"), nil
 	default:
 		return nil, fmt.Errorf("unknown text splitter %q", name)
 	}

--- a/knowledge/pkg/datastore/types/types.go
+++ b/knowledge/pkg/datastore/types/types.go
@@ -19,11 +19,11 @@ type DocumentTransformer interface {
 
 type DocumentLoader interface {
 	Load(ctx context.Context) ([]vs.Document, error)
-	LoadAndSplit(ctx context.Context, splitter TextSplitter) ([]vs.Document, error)
 }
 
 type TextSplitter interface {
 	SplitDocuments(docs []vs.Document) ([]vs.Document, error)
+	Name() string
 }
 
 type Response struct {

--- a/knowledge/pkg/flows/flows.go
+++ b/knowledge/pkg/flows/flows.go
@@ -123,9 +123,8 @@ func (f *IngestionFlow) Run(ctx context.Context, reader io.Reader) ([]vs.Documen
 	/*
 	 * Split documents - Chunking
 	 */
-	splitterLog := phaseLog.With("stage", "textsplitter").With(slog.Int("num_documents", len(docs)))
+	splitterLog := phaseLog.With("stage", "textsplitter").With(slog.Int("num_documents", len(docs))).With("splitter", f.Splitter.Name())
 	splitterLog.With("status", "starting").Info("Starting text splitter")
-
 	docs, err = f.Splitter.SplitDocuments(docs)
 	if err != nil {
 		splitterLog.With("status", "failed").Error("Failed to split documents", "error", err)

--- a/knowledge/pkg/index/models.go
+++ b/knowledge/pkg/index/models.go
@@ -1,8 +1,9 @@
 package index
 
 import (
-	"github.com/gptscript-ai/knowledge/pkg/config"
 	"time"
+
+	"github.com/gptscript-ai/knowledge/pkg/config"
 )
 
 // Dataset refers to a VectorDB data space.
@@ -33,4 +34,5 @@ type Document struct {
 	ID      string `gorm:"primaryKey" json:"id"`
 	Dataset string `gorm:"primaryKey" json:"dataset"` // Foreign key to Dataset, part of composite primary key with FileID
 	FileID  string `gorm:"primaryKey" json:"file_id"` // Foreign key to File, part of composite primary key with Dataset
+	Index   int    `gorm:"index" json:"index"`        // Index of the document in the file (~ location within file, 0-based)
 }

--- a/knowledge/pkg/vectorstore/types/types.go
+++ b/knowledge/pkg/vectorstore/types/types.go
@@ -1,8 +1,58 @@
 package types
 
+import (
+	"slices"
+)
+
 type Document struct {
 	ID              string         `json:"id"`
 	Content         string         `json:"content"`
 	Metadata        map[string]any `json:"metadata"`
 	SimilarityScore float32        `json:"similarity_score"`
+}
+
+const (
+	DocMetadataKeyDocIndex  = "docIndex"
+	DocMetadataKeyDocsTotal = "docsTotal"
+)
+
+func mustInt(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		panic("Unsupported type")
+	}
+}
+
+func SortDocumentsByMetadata(documents []Document, metadataKey string) {
+	// Sort the documents by the metadata field, if present - else we have to assume the order is correct
+	slices.SortFunc(documents, func(i, j Document) int {
+		iVal, ok := i.Metadata[metadataKey]
+		if !ok {
+			return 0
+		}
+		jVal, ok := j.Metadata[metadataKey]
+		if !ok {
+			return 0
+		}
+
+		// Can be either int or float64 (if read from json)
+		return mustInt(iVal) - mustInt(jVal)
+	})
+}
+
+func SortDocumentsByDocIndex(documents []Document) {
+	SortDocumentsByMetadata(documents, DocMetadataKeyDocIndex)
+}
+
+func SortAndEnsureDocIndex(documents []Document) {
+	SortDocumentsByDocIndex(documents)
+	l := len(documents)
+	for i, doc := range documents {
+		doc.Metadata[DocMetadataKeyDocIndex] = i
+		doc.Metadata[DocMetadataKeyDocsTotal] = l
+	}
 }


### PR DESCRIPTION
Adds:
- `docIndex` and `docsTotal` metadata keys (stored in VectorDB)
- `index` column in `documents` table

Fixes:
- PDF documents being re-chunked by textsplitter because chunkOverlap was not considered