### PR TITLE
enhance: slack: add user context

### DIFF
--- a/slack/index.js
+++ b/slack/index.js
@@ -1,6 +1,7 @@
 import { WebClient } from "@slack/web-api"
 import {
-  getChannelHistory, getChannelHistoryByTime,
+  getChannelHistory,
+  getChannelHistoryByTime,
   getDMHistory,
   getDMThreadHistory,
   getMessageLink,
@@ -14,6 +15,7 @@ import {
   sendDMInThread,
   sendMessage,
   sendMessageInThread,
+  userContext,
 } from "./src/tools.js"
 
 if (process.argv.length !== 3) {
@@ -71,6 +73,9 @@ switch (command) {
     break
   case "getDMThreadHistory":
     await getDMThreadHistory(webClient, process.env.USERIDS, process.env.THREADID, process.env.LIMIT)
+    break
+  case "userContext":
+    await userContext(webClient)
     break
   default:
     console.error(`Unknown command: ${command}`)

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -4,11 +4,13 @@ import { Mutex } from "async-mutex"
 export async function userContext(webClient) {
     const result = await webClient.auth.test({})
     const userResult = await webClient.users.info({user: result.user_id})
+    console.log("## Slack user info")
     console.log(`Logged in as ${userResult.user.name}`)
     console.log(`Real Name: ${userResult.user.profile.real_name}`)
     console.log(`Display Name: ${userResult.user.profile.display_name}`)
     console.log(`User ID: ${result.user_id}`)
     console.log(`Default time zone: ${userResult.user.tz_label} (UTC offset ${userResult.user.tz_offset / 3600} hours)`)
+    console.log("## End of Slack user info")
 }
 
 export async function listChannels(webClient) {

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -1,6 +1,18 @@
 import { GPTScript } from "@gptscript-ai/gptscript"
 import { Mutex } from "async-mutex"
 
+export async function userContext(webClient) {
+    const result = await webClient.auth.test({})
+    const userResult = await webClient.users.info({user: result.user_id})
+    console.log(`## Slack user info\n`)
+    console.log(`Logged in as ${userResult.user.name}`)
+    console.log(`Real Name: ${userResult.user.profile.real_name}`)
+    console.log(`Display Name: ${userResult.user.profile.display_name}`)
+    console.log(`User ID: ${result.user_id}`)
+    console.log(`Default time zone: ${userResult.user.tz_label} (UTC offset ${userResult.user.tz_offset / 3600} hours)`)
+    console.log(`\n## End of Slack user info`)
+}
+
 export async function listChannels(webClient) {
     const publicChannels = await webClient.conversations.list({limit: 100, types: 'public_channel'})
     const privateChannels = await webClient.conversations.list({limit: 100, types: 'private_channel'})

--- a/slack/src/tools.js
+++ b/slack/src/tools.js
@@ -4,13 +4,11 @@ import { Mutex } from "async-mutex"
 export async function userContext(webClient) {
     const result = await webClient.auth.test({})
     const userResult = await webClient.users.info({user: result.user_id})
-    console.log(`## Slack user info\n`)
     console.log(`Logged in as ${userResult.user.name}`)
     console.log(`Real Name: ${userResult.user.profile.real_name}`)
     console.log(`Display Name: ${userResult.user.profile.display_name}`)
     console.log(`User ID: ${result.user_id}`)
     console.log(`Default time zone: ${userResult.user.tz_label} (UTC offset ${userResult.user.tz_offset / 3600} hours)`)
-    console.log(`\n## End of Slack user info`)
 }
 
 export async function listChannels(webClient) {

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -174,9 +174,17 @@ Param: limit: the number of messages to return
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getDMThreadHistory
 
 ---
+Name: User Context
+Description: Get information about the logged in user and default time zone.
+Credential: ./credential
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js userContext
+
+---
 Name: Slack Context
 Type: context
 Share Context: ../time
+Share Tools: User Context
 
 #!sys.echo
 
@@ -186,6 +194,8 @@ You have access to a set of tools to interact with a Slack workspace.
 
 Do not provide channel, thread, or message IDs in the output, as these are not helpful for the user.
 When you use the search_messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the list_users or search_users tools.
+
+If you are asked about messages in a particular time frame, call the User Context tool to make sure you know which time zone to use.
 
 ## End of instructions for using Slack tools
 

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -183,8 +183,7 @@ Credential: ./credential
 ---
 Name: Slack Context
 Type: context
-Share Context: ../time
-Share Tools: User Context
+Share Context: ../time, User Context
 
 #!sys.echo
 
@@ -194,8 +193,6 @@ You have access to a set of tools to interact with a Slack workspace.
 
 Do not provide channel, thread, or message IDs in the output, as these are not helpful for the user.
 When you use the search_messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the list_users or search_users tools.
-
-If you are asked about messages in a particular time frame, call the User Context tool to make sure you know which time zone to use.
 
 ## End of instructions for using Slack tools
 


### PR DESCRIPTION
This provides additional context for the Slack tools about who the signed in user is, including their default time zone, so when they ask for things like "list all messages from today in the general channel", the LLM will know what time zone to use.