### PR TITLE
fix: store generated images in datasets instead of workspace files

### DIFF
--- a/images/package-lock.json
+++ b/images/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#306861b8b5aea2ea0481c180067a1687d2726530",
+        "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#56135fadee9445c452f54547b72db864ebae40a9",
         "axios": "^1.7.7",
         "env-paths": "^3.0.0",
         "file-type": "^19.6.0",
@@ -123,8 +123,8 @@
     },
     "node_modules/@gptscript-ai/gptscript": {
       "version": "v0.9.5",
-      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#306861b8b5aea2ea0481c180067a1687d2726530",
-      "integrity": "sha512-/sAVVes46GPfwJcpmrfrV0G2xX9qqj4f+sPJLnOnkl0zyShjedxt61VsDCqe5W2+1QB7QnVQ9oOjgx8vV6OW7g==",
+      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#56135fadee9445c452f54547b72db864ebae40a9",
+      "integrity": "sha512-NDwQhLo+QbOC3MB0ASNbfZw6UHsPxVPICV809mve5Lwzwmdh9zqpcC/mAPDXRDcJfQoFlUqOBb1ii/hZ3xVJIw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/images/package.json
+++ b/images/package.json
@@ -15,7 +15,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#306861b8b5aea2ea0481c180067a1687d2726530",
+    "@gptscript-ai/gptscript": "https://github.com/gptscript-ai/node-gptscript#56135fadee9445c452f54547b72db864ebae40a9",
     "axios": "^1.7.7",
     "env-paths": "^3.0.0",
     "file-type": "^19.6.0",


### PR DESCRIPTION
Use new node-gptscript method to store generated image binary data in datasets instead of as a workspace file.
