### PR TITLE
fix: outlook calendar: createEvent: set event body

### DIFF
--- a/outlook/calendar/pkg/graph/events.go
+++ b/outlook/calendar/pkg/graph/events.go
@@ -84,6 +84,7 @@ func CreateEvent(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, i
 	body := models.NewItemBody()
 	body.SetContent(&info.Body)
 	body.SetContentType(util.Ptr(models.TEXT_BODYTYPE))
+	requestBody.SetBody(body)
 
 	requestBody.SetIsOnlineMeeting(&info.IsOnline)
 


### PR DESCRIPTION
Apparently I just forgot to add this line when I first wrote this tool.