### PR TITLE
fix: slack: fix sending messages in threads

### DIFF
--- a/slack/index.js
+++ b/slack/index.js
@@ -49,7 +49,7 @@ switch (command) {
     await sendMessage(webClient, process.env.CHANNELID, process.env.TEXT)
     break
   case "sendMessageInThread":
-    await sendMessageInThread(webClient, process.env.THREADID, process.env.TEXT)
+    await sendMessageInThread(webClient, process.env.CHANNELID, process.env.THREADID, process.env.TEXT)
     break
   case "listUsers":
     await listUsers(webClient)

--- a/slack/tool.gpt
+++ b/slack/tool.gpt
@@ -93,6 +93,8 @@ Param: channelid: the ID of the channel containing the thread
 Param: threadid: the ID of the thread to send the message to
 Param: text: the text to send
 
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendMessageInThread
+
 ---
 Name: List Users
 Description: List all users in the Slack workspace.


### PR DESCRIPTION
I'm not sure how the code got removed from the tool block in the GPT file, or how I was somehow missing a parameter in the function call, but this fixes both of those problems.