### PR TITLE
fix: add context to prevent notion from creating unwanted pages

### DIFF
--- a/notion/tool.gpt
+++ b/notion/tool.gpt
@@ -94,6 +94,7 @@ Type: Context
 
 You have access to a set of tools to interact with Notion.
 You cannot use the Create Page tool to update the contents of a page. It is only for creating new pages.
+Before creating a new page, confirm that the user wants to create a new page.
 
 ## End of instructions for using Notion tools
 


### PR DESCRIPTION
Add context to the Notion tools to confirm with the user before creating new pages. This will prevent pages from being created when the user is actually attempting to update the content of an existing page.

This change also bumps node-gptscript to include the new dataset changes.

Addresses https://github.com/otto8-ai/otto8/issues/251
