### PR TITLE
enhance: outlook mail: search messages: sort reverse chrono and add start/end params

### DIFF
--- a/outlook/mail/main.go
+++ b/outlook/mail/main.go
@@ -35,7 +35,15 @@ func main() {
 			os.Exit(1)
 		}
 	case "searchMessages":
-		if err := commands.SearchMessages(context.Background(), os.Getenv("SUBJECT"), os.Getenv("FROM_ADDRESS"), os.Getenv("FROM_NAME"), os.Getenv("FOLDER_ID")); err != nil {
+		if err := commands.SearchMessages(
+			context.Background(),
+			os.Getenv("SUBJECT"),
+			os.Getenv("FROM_ADDRESS"),
+			os.Getenv("FROM_NAME"),
+			os.Getenv("FOLDER_ID"),
+			os.Getenv("START"),
+			os.Getenv("END"),
+		); err != nil {
 			fmt.Printf("failed to search messages: %v\n", err)
 			os.Exit(1)
 		}

--- a/outlook/mail/pkg/commands/searchMessages.go
+++ b/outlook/mail/pkg/commands/searchMessages.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gptscript-ai/tools/outlook/mail/pkg/printers"
 )
 
-func SearchMessages(ctx context.Context, subject, fromAddress, fromName, folderID string) error {
+func SearchMessages(ctx context.Context, subject, fromAddress, fromName, folderID, start, end string) error {
 	trueFolderID, err := id.GetOutlookID(folderID)
 	if err != nil {
 		return fmt.Errorf("failed to get folder ID: %w", err)
@@ -22,7 +22,7 @@ func SearchMessages(ctx context.Context, subject, fromAddress, fromName, folderI
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	messages, err := graph.SearchMessages(ctx, c, subject, fromAddress, fromName, trueFolderID)
+	messages, err := graph.SearchMessages(ctx, c, subject, fromAddress, fromName, trueFolderID, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to search messages: %w", err)
 	}

--- a/outlook/mail/pkg/graph/mail.go
+++ b/outlook/mail/pkg/graph/mail.go
@@ -45,7 +45,7 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 		filter []string
 	)
 
-	// It is important that start and end filters are first in the list.
+	// It is important that a receivedDateTime filter is first in the list.
 	// Details in the first answer on this question:
 	// https://learn.microsoft.com/en-us/answers/questions/656200/graph-api-to-filter-results-on-from-and-subject-an
 	if end != "" {

--- a/outlook/mail/pkg/graph/mail.go
+++ b/outlook/mail/pkg/graph/mail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/html"
@@ -37,13 +38,24 @@ func GetMessageDetails(ctx context.Context, client *msgraphsdkgo.GraphServiceCli
 	return result, nil
 }
 
-func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, subject, fromAddress, fromName, folderID string) ([]models.Messageable, error) {
+func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, subject, fromAddress, fromName, folderID, start, end string) ([]models.Messageable, error) {
 	var (
 		result models.MessageCollectionResponseable
 		err    error
 		filter []string
 	)
 
+	// It is important that start and end filters are first in the list.
+	// Details in the first answer on this question:
+	// https://learn.microsoft.com/en-us/answers/questions/656200/graph-api-to-filter-results-on-from-and-subject-an
+	if end != "" {
+		filter = append(filter, fmt.Sprintf("receivedDateTime le %s", end))
+	} else {
+		// Using the receivedDateTime in the orderBy parameter requires us to have it in the filter as well.
+		// So we ask for messages that were received prior to tomorrow, which should be all messages.
+		tomorrow := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+		filter = append(filter, fmt.Sprintf("receivedDateTime le %s", tomorrow))
+	}
 	if subject != "" {
 		filter = append(filter, fmt.Sprintf("contains(subject, '%s')", subject))
 	}
@@ -53,6 +65,9 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	if fromName != "" {
 		filter = append(filter, fmt.Sprintf("contains(from/emailAddress/name, '%s')", fromName))
 	}
+	if start != "" {
+		filter = append(filter, fmt.Sprintf("receivedDateTime ge %s", start))
+	}
 
 	if len(filter) == 0 {
 		return nil, fmt.Errorf("at least one of subject, from_address, or from_name must be provided")
@@ -61,15 +76,17 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	if folderID != "" {
 		result, err = client.Me().MailFolders().ByMailFolderId(folderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 			QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
-				Filter: util.Ptr(strings.Join(filter, " and ")),
-				Top:    util.Ptr(int32(10)),
+				Orderby: []string{"receivedDateTime DESC"},
+				Filter:  util.Ptr(strings.Join(filter, " and ")),
+				Top:     util.Ptr(int32(10)),
 			},
 		})
 	} else {
 		result, err = client.Me().Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
 			QueryParameters: &users.ItemMessagesRequestBuilderGetQueryParameters{
-				Filter: util.Ptr(strings.Join(filter, " and ")),
-				Top:    util.Ptr(int32(10)),
+				Orderby: []string{"receivedDateTime DESC"},
+				Filter:  util.Ptr(strings.Join(filter, " and ")),
+				Top:     util.Ptr(int32(10)),
 			},
 		})
 	}

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -44,6 +44,8 @@ Param: subject: (Optional) Search query for the subject of the message.
 Param: from_address: (Optional) Search query for the email address of the sender.
 Param: from_name: (Optional) Search query for the name of the sender.
 Param: folder_id: (Optional) The ID of the folder to search in. If unset, will search all folders.
+Param: start: (Optional) The start date and time of the time frame to search within, in RFC 3339 format.
+Param: end: (Optional) The end date and time of the time frame to search within, in RFC 3339 format.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool searchMessages
 


### PR DESCRIPTION
This adds new `start` and `end` params as bounds for the Search Messages tool, and also now provides search results in reverse chronological (most recent first) order.