### PR TITLE
enhance: generate image paths accessible to the otto8 ui

### DIFF
--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -17,7 +17,8 @@ Param: images: (required) Comma delimited list containing one or more image URIs
 ---
 Name: Generate Images
 Credential: github.com/gptscript-ai/credentials/model-provider
-Description: Generates images based on the specified parameters and returns a list of URLs to the generated images
+Description: Generates images based on the specified parameters and returns a list of file paths to the generated images
+Share Context: Images Context
 Param: model: (optional) A model with image generation capabilities to use for the generation (default dall-e-3)
 Param: prompt: (required) Text describing the images to generate
 Param: size: (optional) Dimensions of the images to generate in. One of [1024x1024, 256x256, 512x512, 1792x1024, 1024x1792] (default 1024x1024)
@@ -25,6 +26,18 @@ Param: quality: (optional) Quality of the generated image. One of [standard, hd]
 Param: quantity: (optional) Quantity of distinct images to generate (default 1, max 10)
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- generateImages
+
+---
+Name: Images Context
+Type: context
+
+#!sys.echo
+
+## Instructions for using the Images tools
+
+When referencing generated image paths, always use the exact file path returned by the Generate Images tool without any modification. **Do not add any protocol prefixes** (such as `http://` or `https://`). Only use the exact path as provided.
+
+## End of instructions for using the Images tools
 
 ---
 !metadata:*:category


### PR DESCRIPTION
Return file paths from the Generate Image tool that can be accessed by the Otto8 UI and share a new context tool to prevent LLMs from tacking on a HTTPS protocol prefix (`gpt-4o` couldn't resist...)

**Before**: `files/<image>.png`
**After**:  `/api/threads/<thread_id>/file/<image>.png`

Additionally, change the convention for generated file names to make their origin more clear.

**Before**: `550d3ea4c5d64d727486f62da2d1d0ed5b0e59246d8e922a92b48c5a9e37f3a5.png`
**After**:  `generated_image_550d3ea4.png`

## E.g

<img width="761" alt="Screenshot 2024-11-08 at 10 41 22 PM" src="https://github.com/user-attachments/assets/70f159aa-7ff9-4d6a-8cd8-97414f39078f">

<img width="450" alt="Screenshot 2024-11-08 at 10 41 43 PM" src="https://github.com/user-attachments/assets/02e154b6-f699-49a2-a2b5-fa0d8addd28c">
