### PR TITLE
enhance: analyze image workspace file support

### DIFF
--- a/images/src/generate.ts
+++ b/images/src/generate.ts
@@ -8,13 +8,13 @@ type ImageQuality = 'standard' | 'hd';
 
 const threadId = process.env.OTTO_THREAD_ID;
 
-const generateImages = async (
+export async function generateImages(
   model: string = 'dall-e-3',
   prompt: string = '',
   size: string = '1024x1024',
   quality: string = 'standard',
   quantity: number = 1
-): Promise<void> => {
+): Promise<void> {
   if (!prompt) {
     throw new Error('No prompt provided. Please provide a prompt to generate images.');
   }
@@ -75,5 +75,3 @@ async function download(client: gptscript.GPTScript, imageUrl: string): Promise<
 
   return filePath
 }
-
-export { generateImages };

--- a/images/src/tools.ts
+++ b/images/src/tools.ts
@@ -14,8 +14,7 @@ try {
             analyzeImages(
                 process.env.MODEL,
                 process.env.PROMPT,
-                // Split the string into an array of image URLs, while being careful to handle URLs that contain commas.
-                process.env.IMAGES?.split(/(?<!\\),/).map(image => image.replace(/\\,/g, ',')),
+                process.env.IMAGES,
             )
             break
         case 'generateImages':

--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -1,23 +1,24 @@
 ---
 Name: Images
 Metadata: bundle: true
-Description: Tools for analyzing and generating images 
+Description: Tools for analyzing and generating images
 Share Tools: Analyze Images, Generate Images
 
 ---
 Name: Analyze Images
 Credential: github.com/gptscript-ai/credentials/model-provider
 Description: Analyze images using a given prompt and return relevant information about the images
+Share Context: Images Context
 Param: model: (optional) A model with vision capabilities to use for the analysis
-Param: prompt: (required) A prompt to analyze the images with
-Param: images: (required) Comma delimited list containing one or more image URIs to analyze. Valid URIs start with "http://" and "https://" for remote images, and no protocol for file paths to local images. Only supports jpeg and png. Commas in file paths should be escaped with a backslash
+Param: prompt: (optional) A prompt to analyze the images with (defaults "Provide a brief description of each image")
+Param: images: (required) A JSON array containing one or more URLs or file paths of images to analyze. Only supports jpegs and pngs.
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- analyzeImages
 
 ---
 Name: Generate Images
 Credential: github.com/gptscript-ai/credentials/model-provider
-Description: Generates images based on the specified parameters and returns a list of absolute file paths to the generated images
+Description: Generate images and return their file paths
 Share Context: Images Context
 Param: model: (optional) A model with image generation capabilities to use for the generation (default dall-e-3)
 Param: prompt: (required) Text describing the images to generate
@@ -35,8 +36,12 @@ Type: context
 
 ## Instructions for using the Generate Images and Analyze Images tools ##
 
-Always use the exact file paths returned by the Generate Images tool when embedding them in markdown.
+__Always use the exact file paths returned by the Generate Images tool when embedding them in markdown.__
 For example, if Generate Images returns `/api/threads/123abc/generated_image_defg1234.png`, you should use `![Image Title](/api/threads/123abc/generated_image_defg1234.png)` in your response.
+
+__Always pass the Analyze Images tool a valid JSON array for the `images` parameter. Do this even when you only have a single image to analyze. The array must always contain one or more URLs and or file paths.__
+e.g. Analyzing a single image: `["https://example.com/image1.png"]`
+e.g. Analyzing multiple images: `["https://example.com/image1.png", "cool.jpg", "/api/threads/123abc/generated_image_defg1234.png", "https://example.com/image2.png"]`
 
 ## Instructions for using the Generate Images and Analyze Images tools ##
 


### PR DESCRIPTION
Add support for analyzing image files from the workspace. This enables users to analyze images generated by `Generate Images` in addition to files they've directly uploaded to the workspace.

Addresses: https://github.com/otto8-ai/otto8/issues/431
