### PR TITLE
chore: temporarily de-index youtube transcriber

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -23,9 +23,6 @@ tools:
   google-sheets:
     reference: ./google/sheets
     all: true
-  google-youtube:
-    reference: ./google/youtube
-    all: true
   images:
     reference: ./images
     all: true


### PR DESCRIPTION
Google blocks transcript requests from certain public cloud IPs,
which breaks the `YouTube Transcriber` tool when it's running from
our test and demo instances in Render.

A workaround won't be ready in time for Kubecon, so this change
removes it from the index for now.

See https://acorn-io.slack.com/archives/C03FU91U4SX/p1731181637315179
for details.

