### PR TITLE
chore: remove model params from google search and images tools

### DIFF
--- a/google/search/src/refine.ts
+++ b/google/search/src/refine.ts
@@ -3,7 +3,7 @@ import { type SearchResults, type SearchResult } from './search.ts'
 
 const gptscript = new GPTScript()
 
-export async function refine (model: string, unrefined: SearchResults): Promise<SearchResults> {
+export async function refine (unrefined: SearchResults): Promise<SearchResults> {
   const now = new Date().toISOString()
   const refined = await Promise.all(
     unrefined.results.map(async (result) => {
@@ -12,7 +12,7 @@ export async function refine (model: string, unrefined: SearchResults): Promise<
         return result
       }
 
-      return await refineResult(model, now, unrefined.query, result)
+      return await refineResult(now, unrefined.query, result)
     })
   )
 
@@ -27,7 +27,6 @@ function hasContent (content?: string | string[]): boolean {
 }
 
 async function refineResult (
-  model: string,
   time: string,
   query: string,
   result: SearchResult): Promise<SearchResult> {
@@ -35,7 +34,7 @@ async function refineResult (
   const tool: ToolDef = {
     chat: false,
     jsonResponse: true,
-    modelName: model,
+    modelName: 'gpt-4o-mini',
     temperature: 0.0,
     arguments: {
       type: 'object',

--- a/google/search/src/server.ts
+++ b/google/search/src/server.ts
@@ -30,7 +30,6 @@ async function main (): Promise<void> {
 
       const data = req.body
       const maxResults = Number.isInteger(Number(data.maxResults)) ? parseInt(data.maxResults as string, 10) : 3
-      const model: string = data.model !== '' ? data.model : 'gpt-4o-mini'
       const query: string = data.query ?? ''
       const sessionID = getSessionId(req.headers)
 
@@ -44,10 +43,7 @@ async function main (): Promise<void> {
         const searchEnd = performance.now()
 
         // Extract the relevant citations from the content of each page
-        const refinedResults = await refine(
-          model,
-          searchResults
-        )
+        const refinedResults = await refine(searchResults)
         const refineEnd = performance.now()
 
         res.status(200).send(JSON.stringify({

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -6,12 +6,10 @@ Share Tools: Search
 
 ---
 Name: Search
-Credential: github.com/gptscript-ai/credentials/model-provider
 Description: Search Google with a given query and return relevant information from the search results
 JSON Response: true
 Share Context: ../../time
 Tools: service
-Args: model: The LLM model to use for the search (optional, default gpt-4o-mini)
 Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3)
 Args: query: A question, statement, or topic to search with (required)
 

--- a/images/src/analyze.ts
+++ b/images/src/analyze.ts
@@ -6,7 +6,6 @@ import { ChatCompletionContentPartImage } from 'openai/resources/chat/completion
 import { GPTScript } from '@gptscript-ai/gptscript';
 
 export async function analyzeImages(
-  model: string = 'gpt-4o',
   prompt: string = '',
   images: string = '[]',
 ): Promise<void> {
@@ -38,7 +37,7 @@ export async function analyzeImages(
 
   const openai = new OpenAI();
   const response = await openai.chat.completions.create({
-    model: model,
+    model: 'gpt-4o',
     stream: true,
     messages: [
       {

--- a/images/src/generate.ts
+++ b/images/src/generate.ts
@@ -9,7 +9,6 @@ type ImageQuality = 'standard' | 'hd';
 const threadId = process.env.OTTO_THREAD_ID;
 
 export async function generateImages(
-  model: string = 'dall-e-3',
   prompt: string = '',
   size: string = '1024x1024',
   quality: string = 'standard',
@@ -35,7 +34,7 @@ export async function generateImages(
 
   try {
     const response = await openai.images.generate({
-      model,
+      model: 'dall-e-3',
       prompt,
       size: size as ImageSize,
       quality: quality as ImageQuality,

--- a/images/src/tools.ts
+++ b/images/src/tools.ts
@@ -12,14 +12,12 @@ try {
     switch (command) {
         case 'analyzeImages':
             analyzeImages(
-                process.env.MODEL,
                 process.env.PROMPT,
                 process.env.IMAGES,
             )
             break
         case 'generateImages':
             generateImages(
-                process.env.MODEL,
                 process.env.PROMPT,
                 process.env.SIZE,
                 process.env.QUALITY,

--- a/images/tool.gpt
+++ b/images/tool.gpt
@@ -9,7 +9,6 @@ Name: Analyze Images
 Credential: github.com/gptscript-ai/credentials/model-provider
 Description: Analyze images using a given prompt and return relevant information about the images
 Share Context: Images Context
-Param: model: (optional) A model with vision capabilities to use for the analysis
 Param: prompt: (optional) A prompt to analyze the images with (defaults "Provide a brief description of each image")
 Param: images: (required) A JSON array containing one or more URLs or file paths of images to analyze. Only supports jpegs and pngs.
 
@@ -20,7 +19,6 @@ Name: Generate Images
 Credential: github.com/gptscript-ai/credentials/model-provider
 Description: Generate images and return their file paths
 Share Context: Images Context
-Param: model: (optional) A model with image generation capabilities to use for the generation (default dall-e-3)
 Param: prompt: (required) Text describing the images to generate
 Param: size: (optional) Dimensions of the images to generate in. One of [1024x1024, 256x256, 512x512, 1792x1024, 1024x1792] (default 1024x1024)
 Param: quality: (optional) Quality of the generated image. One of [standard, hd] (default standard)


### PR DESCRIPTION
Remove `Model` tool parameters. The models used by these tools shouldn't change.