### PR TITLE
Fix: make sure slash is appended after baseUrl path

### DIFF
--- a/knowledge/data-sources/website/colly.go
+++ b/knowledge/data-sources/website/colly.go
@@ -183,6 +183,9 @@ func scrape(ctx context.Context, converter *md.Converter, logOut *logrus.Logger,
 			}
 
 			if linkURL.Host == "" && !strings.HasPrefix(link, "#") {
+				if !strings.HasSuffix(baseURL.Path, "/") {
+					baseURL.Path += "/"
+				}
 				fullLink := baseURL.ResolveReference(linkURL).String()
 				parsedLink, err := url2.Parse(fullLink)
 				if err != nil {


### PR DESCRIPTION
When comparing linkurl with baseURl, we should always add "/" after the path. This is so that `www.acorn.io/docs` doesn't get dropped when resolving link reference to `index.yaml`. Without "/" it will intepret as `www.acorn.io/index.yaml` instead of `www.acorn.io/docs/index.yaml`

https://github.com/otto8-ai/otto8/issues/595#event-15306143444