### PR TITLE
chore: more generous OpenAI API timeouts for expensive requests + per-request timeouts

### DIFF
--- a/knowledge/pkg/datastore/defaults/defaults.go
+++ b/knowledge/pkg/datastore/defaults/defaults.go
@@ -13,4 +13,12 @@ const (
 	ChunkOverlapTokens = 256
 )
 
-var ModelAPIRequestTimeoutSeconds = env.GetIntFromEnvOrDefault("KNOW_MODEL_API_REQUEST_TIMEOUT_SECONDS", 120)
+var (
+	// Default Remote Model API timeout options
+
+	// ModelAPITimeoutSeconds is the total timeout set on the context and is the maximum time we try for, so it may span multiple retries
+	ModelAPITimeoutSeconds = env.GetIntFromEnvOrDefault("KNOW_MODEL_API_TIMEOUT_SECONDS", 300)
+
+	// ModelAPIRequestTimeoutSeconds is the timeout for each individual request to the model API
+	ModelAPIRequestTimeoutSeconds = env.GetIntFromEnvOrDefault("KNOW_MODEL_API_REQUEST_TIMEOUT_SECONDS", 120)
+)


### PR DESCRIPTION
`KNOW_MODEL_API_TIMEOUT_SECONDS` - 300s (set on context)
`KNOW_MODEL_API_REQUEST_TIMEOUT_SECONDS` - 120s (set on http client - long time sometimes required for VLM calls)

... can be overridden for embeddings and for "OCR"/VLM calls