### PR TITLE
enhance: enable listing outlook messages by time

### DIFF
--- a/outlook/mail/main.go
+++ b/outlook/mail/main.go
@@ -25,7 +25,13 @@ func main() {
 			os.Exit(1)
 		}
 	case "listMessages":
-		if err := commands.ListMessages(context.Background(), os.Getenv("FOLDER_ID")); err != nil {
+		if err := commands.ListMessages(
+			context.Background(),
+			os.Getenv("FOLDER_ID"),
+			os.Getenv("START"),
+			os.Getenv("END"),
+			os.Getenv("LIMIT"),
+		); err != nil {
 			fmt.Printf("failed to list mail: %v\n", err)
 			os.Exit(1)
 		}

--- a/outlook/mail/tool.gpt
+++ b/outlook/mail/tool.gpt
@@ -15,12 +15,15 @@ Credential: Outlook Mail OAuth Read Credential from ./credential
 
 ---
 Name: List Messages
-Description: Lists all messages in a folder.
+Description: Lists messages in a folder.
 Share Context: Outlook Mail Context
 Tools: github.com/gptscript-ai/datasets/filter
 Credential: Outlook Mail OAuth Read Credential from ./credential
 Share Tools: List Mail Folders
 Param: folder_id: The ID of the folder to list messages in.
+Param: start: (Optional) The start date and time of the time frame to list messages within, in RFC 3339 format.
+Param: end: (Optional) The end date and time of the time frame to list messages within, in RFC 3339 format.
+Param: limit: (Optional) The maximum number of messages to return. If unset, returns up to 100 messages.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listMessages
 


### PR DESCRIPTION
Add optional `start`, `end`, and `limit` parameters to the `Outlook
Mail` bundle's `List Messages` tool. This enables listing emails by date
and supports prompts like "List the latest ${N} emails on ${DATE}".

Addresses https://github.com/otto8-ai/otto8/issues/384

