### PR TITLE
fix: tweak notion context to prevent page creation when asked to update

### DIFF
--- a/notion/tool.gpt
+++ b/notion/tool.gpt
@@ -94,7 +94,7 @@ Type: Context
 
 You have access to a set of tools to interact with Notion.
 You cannot use the Create Page tool to update the contents of a page. It is only for creating new pages.
-Before creating a new page, confirm that the user wants to create a new page.
+Every time you are about to create a new page and the user isn't explicitly asking for one, ask them to confirm before proceeding.
 
 ## End of instructions for using Notion tools
 


### PR DESCRIPTION
Tweak the `Notion` bundle context to prevent pages from being created
automatically when a user asks to "update" or "add to" a given page.
The context instructs Agents to ask the user to confirm before it calls `Create Page` when the user hasn't explicitly asked for a page to be created.

The current context is just ambiguous enough for agents to interpret a single
confirmation of "create a new page with the updated content" as
confirmation for all subsequent prompts. This change has prevented that
in my testing.

> **Note:** IMO we should implement a true `Update Page` tool page as soon as we have the time.

Addresses https://github.com/otto8-ai/otto8/issues/251
