### PR TITLE
Fix filepath

### DIFF
--- a/knowledge/data-sources/notion/.prettierrc
+++ b/knowledge/data-sources/notion/.prettierrc
@@ -1,1 +1,12 @@
-{}
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false,
+    "trailingComma": "es5",
+    "bracketSpacing": true,
+    "jsxBracketSameLine": false,
+    "importOrder": ["<THIRD_PARTY_MODULES>", "^~/lib", "^~/(.*)$", "^[./]"],
+    "importOrderSeparation": true,
+    "importOrderSortSpecifiers": true
+}

--- a/knowledge/data-sources/onedrive/main.go
+++ b/knowledge/data-sources/onedrive/main.go
@@ -182,12 +182,15 @@ func sync(ctx context.Context, logErr *logrus.Logger, input MetadataInput, outpu
 			return err
 		}
 		for _, child := range children {
-			items[*child.GetId()] = struct {
-				Item models.DriveItemable
-				Root string
-			}{
-				Item: child,
-				Root: root,
+			// We only sync item that is less than 50 MB, as most of the bigger files won't be supported from knowledge
+			if child.GetSize() != nil && *child.GetSize() < 1024*1024*50 {
+				items[*child.GetId()] = struct {
+					Item models.DriveItemable
+					Root string
+				}{
+					Item: child,
+					Root: root,
+				}
 			}
 		}
 	}

--- a/knowledge/data-sources/website/main.go
+++ b/knowledge/data-sources/website/main.go
@@ -32,12 +32,7 @@ type State struct {
 }
 
 type WebsiteCrawlingState struct {
-	Folders map[string]struct{}    `json:"folders"`
-	Pages   map[string]PageDetails `json:"pages"`
-}
-
-type PageDetails struct {
-	ParentURL string `json:"parentURL"`
+	Folders map[string]struct{} `json:"folders"`
 }
 
 type FileDetails struct {
@@ -89,10 +84,6 @@ func main() {
 
 	if output.Files == nil {
 		output.Files = make(map[string]FileDetails)
-	}
-
-	if output.State.WebsiteCrawlingState.Pages == nil {
-		output.State.WebsiteCrawlingState.Pages = make(map[string]PageDetails)
 	}
 
 	mode := os.Getenv("MODE")


### PR DESCRIPTION
1. Rewrite notion sync tool to be more effifient.
2. Limit onedrive file to be < 50mb.
3. Use filepath as key in website scraper.

https://github.com/otto8-ai/otto8/issues/642
https://github.com/otto8-ai/otto8/issues/625
https://github.com/otto8-ai/otto8/issues/637