### PR TITLE
enhance: enable attaching workspace files when creating gmail drafts and sending emails

### DIFF
--- a/google/gmail/requirements.txt
+++ b/google/gmail/requirements.txt
@@ -1,3 +1,4 @@
+filetype
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -64,6 +64,7 @@ Credential: ../credential
 Share Contexts: ../../time, Email List Context
 Tools: github.com/gptscript-ai/datasets/filter
 Param: max_results: Maximum number of drafts to list (Optional: Default will list all drafts)
+Param: attachments: A comma separated list of workspace file paths to attach to the email (Optional)
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/listDrafts.py
 

--- a/google/gmail/tool.gpt
+++ b/google/gmail/tool.gpt
@@ -78,6 +78,7 @@ Param: cc_emails: A comma separated list of email addresses to cc the email to (
 Param: bcc_emails: A comma separated list of email addresses to bcc the email to (Optional)
 Param: subject: Subject of the email
 Param: message: Message body of the email
+Param: attachments: A comma separated list of workspace file paths to attach to the email (Optional)
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/createDraft.py
 


### PR DESCRIPTION
Add an optional `attachments` parameter to the `Gmail` bundle's `Create Draft` and `Send Email` tools to enable attaching workspace files when creating drafts and sending emails.

Addresses https://github.com/otto8-ai/otto8/issues/115 for the `Gmail` tool bundle
