### PR TITLE
change: bring back website cleaning, but act on a copy of the DOM as to not remove links (e.g. from nav) before we checked them out.

### DIFF
--- a/knowledge/data-sources/website/clean.go
+++ b/knowledge/data-sources/website/clean.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/PuerkitoBio/goquery"
+)
+
+var excludeNonMainTags = []string{
+	"script, style, noscript, meta, head",
+	"header", "footer", "nav", "aside", ".header", ".top", ".navbar", "#header",
+	".footer", ".bottom", "#footer", ".sidebar", ".side", ".aside", "#sidebar",
+	".modal", ".popup", "#modal", ".overlay", ".ad", ".ads", ".advert", "#ad",
+	".lang-selector", ".language", "#language-selector", ".social", ".social-media",
+	".social-links", "#social", ".menu", ".navigation", "#nav", ".breadcrumbs",
+	"#breadcrumbs", "#search-form", ".search", "#search", ".share", "#share",
+	".widget", "#widget", ".cookie", "#cookie",
+}
+
+func RemoveNonMainContent(doc *goquery.Selection) *goquery.Selection {
+	for _, tag := range excludeNonMainTags {
+		doc.Find(tag).Remove()
+	}
+	return doc
+}


### PR DESCRIPTION
This reverts commit 6ceec6f79cce871fae1fecc0c3b720502eba2b19.

Part of enhancement addressing https://github.com/otto8-ai/otto8/issues/386