### PR TITLE
Fix: fix link url to be sub-domain

### DIFF
--- a/knowledge/data-sources/website/colly.go
+++ b/knowledge/data-sources/website/colly.go
@@ -216,11 +216,9 @@ func isSameDomainOrSubdomain(linkHostname, baseHostname string) bool {
 
 	// if baseHostname is x.y, linkHostname can be www*.x.y
 	if len(parts) == 2 {
-		if strings.HasSuffix(linkHostname, baseHostname) {
-			linkParts := strings.Split(linkHostname, ".")
-			if len(linkParts) == 3 && (linkParts[0] == "www" || (len(linkParts[0]) == 4 && strings.HasPrefix(linkParts[0], "www"))) {
-				return true
-			}
+		linkParts := strings.Split(linkHostname, ".")
+		if len(linkParts) == 3 && (linkParts[0] == "www" || (len(linkParts[0]) == 4 && strings.HasPrefix(linkParts[0], "www"))) {
+			return strings.Join(linkParts[1:], ".") == baseHostname
 		}
 	}
 

--- a/knowledge/data-sources/website/colly_test.go
+++ b/knowledge/data-sources/website/colly_test.go
@@ -19,6 +19,7 @@ func TestIsSameDomainOrSubdomain(t *testing.T) {
 		{"example.com", "example.net", false},          // different base domains
 		{"blog.example.com", "www.example.com", false}, // base with www, unrelated subdomain
 		{"www.example.com", "www.example.com", true},   // exact match with www prefix
+		{"www.ukcry.org", "cry.org", false},            // exact match with www prefix
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
https://github.com/otto8-ai/otto8/issues/675

Previously it onlys check for suffix which is not enough. It needs to check the last two parts of the url after splitted by `.`.