### PR TITLE
feat: add a fake model provider credential

### DIFF
--- a/anthropic-model-provider/tool.gpt
+++ b/anthropic-model-provider/tool.gpt
@@ -2,5 +2,6 @@ Name: Anthropic
 Description: Model provider for Anthropic hosted Claude3 models
 Metadata: envVars: OTTO8_ANTHROPIC_MODEL_PROVIDER_API_KEY
 Model Provider: true
+Credential: ../model-provider-credential as anthropic-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/azure-openai-model-provider/tool.gpt
+++ b/azure-openai-model-provider/tool.gpt
@@ -2,5 +2,6 @@ Name: Azure OpenAI
 Description: Model provider for Azure OpenAI hosted models
 Metadata: envVars: OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP
 Model Provider: true
+Credential: ../model-provider-credential as azure-openai-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/model-provider-credential/tool.gpt
+++ b/model-provider-credential/tool.gpt
@@ -1,0 +1,7 @@
+Name: Model Provider credential
+Description: This is a fake credential tool for the model providers. These credentials are handled in Otto8 and this tool should never be called.
+
+#!/bin/bash
+
+echo "The credential has not been properly configured"
+exit 1

--- a/ollama-model-provider/tool.gpt
+++ b/ollama-model-provider/tool.gpt
@@ -2,5 +2,6 @@ Name: Ollama
 Description: Model provider for models running on Ollama
 Metadata: envVars: OTTO8_OLLAMA_MODEL_PROVIDER_HOST
 Model Provider: true
+Credential: ../model-provider-credential as ollama-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/openai-model-provider/tool.gpt
+++ b/openai-model-provider/tool.gpt
@@ -2,5 +2,6 @@ Name: OpenAI
 Description: Model Provider for OpenAI
 Metadata: envVars: OTTO8_OPENAI_MODEL_PROVIDER_API_KEY
 Model Provider: true
+Credential: ../model-provider-credential as openai-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py

--- a/voyage-model-provider/tool.gpt
+++ b/voyage-model-provider/tool.gpt
@@ -2,5 +2,6 @@ Name: Voyage
 Description: Model provider for Voyage Embeddings
 Metadata: envVars: OTTO8_VOYAGE_MODEL_PROVIDER_API_KEY
 Model Provider: true
+Credential: ../model-provider-credential as voyage-model-provider
 
 #!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py


### PR DESCRIPTION
This model provider credential exists only so that the environment variables are given to the tool when it runs. The actual credential is managed by Otto8 itself. If the credential is called, that means that the model provider has not been properly configured.