### PR TITLE
Fix: dedup pdf path if it belongs to the base url

### DIFF
--- a/knowledge/data-sources/website/colly.go
+++ b/knowledge/data-sources/website/colly.go
@@ -243,7 +243,10 @@ func scrapePDF(ctx context.Context, logOut *logrus.Logger, output *MetadataOutpu
 			return fmt.Errorf("invalid link URL %s: %v", fullLink, err)
 		}
 	}
-	filePath := path.Join(baseURL.Host, linkURL.Host, strings.TrimPrefix(linkURL.Path, "/"))
+	filePath := path.Join(linkURL.Host, strings.TrimPrefix(linkURL.Path, "/"))
+	if !isSameDomainOrSubdomain(linkURL.Host, baseURL.Host) {
+		filePath = path.Join(baseURL.Host, filePath)
+	}
 	if _, ok := visited[filePath]; ok {
 		return nil
 	}


### PR DESCRIPTION
Fix so that if external pdf link belongs to the same base url folder, combine the path and remove duplicated hostname. The original intention is to place external pdf link to the base url folder with its path as the subfolder. But if the link belong to the same url, the hostname dir can be combined. 

https://github.com/otto8-ai/otto8/issues/674