### PR TITLE
Fix: Increase timout to 4 minutes, increase overall timeout

### DIFF
--- a/knowledge/pkg/datastore/embeddings/openai/openai.go
+++ b/knowledge/pkg/datastore/embeddings/openai/openai.go
@@ -16,15 +16,14 @@ import (
 	"time"
 
 	"dario.cat/mergo"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/load"
 	"github.com/gptscript-ai/knowledge/pkg/env"
 	"github.com/gptscript-ai/knowledge/pkg/log"
 	cg "github.com/philippgille/chromem-go"
 )
 
-var OpenAIEmbeddingAPITimeout = time.Duration(env.GetIntFromEnvOrDefault("KNOW_OPENAI_EMBEDDING_API_TIMEOUT_SECONDS", defaults.ModelAPIRequestTimeoutSeconds)) * time.Second
-var OpenAIEmbeddingAPIRequestTimeout = time.Duration(env.GetIntFromEnvOrDefault("KNOW_OPENAI_EMBEDDING_API_REQUEST_TIMEOUT_SECONDS", 120)) * time.Second
+var OpenAIEmbeddingAPITimeout = time.Duration(env.GetIntFromEnvOrDefault("KNOW_OPENAI_EMBEDDING_API_TIMEOUT_SECONDS", 1200)) * time.Second
+var OpenAIEmbeddingAPIRequestTimeout = time.Duration(env.GetIntFromEnvOrDefault("KNOW_OPENAI_EMBEDDING_API_REQUEST_TIMEOUT_SECONDS", 240)) * time.Second
 
 const EmbeddingModelProviderOpenAIName string = "openai"
 


### PR DESCRIPTION
We are seeing increased timeout error when trying to make embedding requests, so this PR increases the timeout per requests. Also increase the overall context timout to be the 5x of the requests so that it can actually try 5 times. 

https://github.com/otto8-ai/otto8/issues/591