### PR TITLE
fix: CreatePage tool fix -- split content if it exceeds length limit 2000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/venv
 **/bin
 **/node_modules
+*__pycache__

--- a/notion/src/pages.js
+++ b/notion/src/pages.js
@@ -51,12 +51,9 @@ function sliceAndMergeContents(contents, maxLength = 2000) {
 export async function createPage(client, name, contents, parentPageId) {
     const contentChunks = sliceAndMergeContents(contents);
 
-    const children = contentChunks.map(chunk => ({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-            rich_text: [{ type: "text", text: { content: chunk } }],
-        },
+    const richTexts = contentChunks.map(chunk => ({
+        type: "text",
+        text: { content: chunk.trim() }
     }));
 
     // Create the page with sliced chunks as children
@@ -67,7 +64,15 @@ export async function createPage(client, name, contents, parentPageId) {
         properties: {
             title: [{ type: "text", text: { content: name } }],
         },
-        children: children,
+        children: [
+            {
+                object: "block",
+                type: "paragraph",
+                paragraph: {
+                    rich_text: richTexts,
+                },
+            },
+        ],
     });
 
     console.log(`Created page with ID: ${page.id}`);

--- a/notion/src/pages.js
+++ b/notion/src/pages.js
@@ -1,60 +1,60 @@
 import {getPropertyString} from "./database.js"
 
 function sliceAndMergeContents(contents, maxLength = 2000) {
-    let chunks = [];
-    let tempChunks = contents.split('\n');
-    let currentChunk = "";
+    let chunks = []
+    let tempChunks = contents.split('\n')
+    let currentChunk = ""
 
     for (let chunk of tempChunks) {
         // If adding the current chunk exceeds the limit, push the accumulated chunk
         if ((currentChunk + chunk + '\n').length > maxLength) {
-            chunks.push(currentChunk.trim());
-            currentChunk = chunk + '\n';
+            chunks.push(currentChunk.trim())
+            currentChunk = chunk + '\n'
         } else {
-            currentChunk += chunk + '\n';
+            currentChunk += chunk + '\n'
         }
     }
 
     // Push the remaining chunk
     if (currentChunk.trim().length > 0) {
-        chunks.push(currentChunk.trim());
+        chunks.push(currentChunk.trim())
     }
 
     // Further split any chunk that still exceeds maxLength using `.`
-    let finalChunks = [];
+    let finalChunks = []
     for (let chunk of chunks) {
         if (chunk.length > maxLength) {
-            let subChunks = chunk.split('.');
-            let mergedChunk = "";
+            let subChunks = chunk.split('.')
+            let mergedChunk = ""
 
             for (let subChunk of subChunks) {
                 if ((mergedChunk + subChunk + '.').length > maxLength) {
-                    finalChunks.push(mergedChunk.trim());
-                    mergedChunk = subChunk + '.';
+                    finalChunks.push(mergedChunk.trim())
+                    mergedChunk = subChunk + '.'
                 } else {
-                    mergedChunk += subChunk + '.';
+                    mergedChunk += subChunk + '.'
                 }
             }
 
             // Push the remaining part
             if (mergedChunk.trim().length > 0) {
-                finalChunks.push(mergedChunk.trim());
+                finalChunks.push(mergedChunk.trim())
             }
         } else {
-            finalChunks.push(chunk);
+            finalChunks.push(chunk)
         }
     }
 
-    return finalChunks;
+    return finalChunks
 }
 
 export async function createPage(client, name, contents, parentPageId) {
-    const contentChunks = sliceAndMergeContents(contents);
+    const contentChunks = sliceAndMergeContents(contents)
 
     const richTexts = contentChunks.map(chunk => ({
         type: "text",
         text: { content: chunk.trim() }
-    }));
+    }))
 
     // Create the page with sliced chunks as children
     const page = await client.pages.create({
@@ -73,10 +73,11 @@ export async function createPage(client, name, contents, parentPageId) {
                 },
             },
         ],
-    });
+    })
 
-    console.log(`Created page with ID: ${page.id}`);
+    console.log(`Created page with ID: ${page.id}`)
 }
+
 
 export async function printPageProperties(client, id) {
     const page = await client.pages.retrieve({page_id: id})

--- a/notion/src/pages.js
+++ b/notion/src/pages.js
@@ -1,20 +1,76 @@
 import {getPropertyString} from "./database.js"
 
+function sliceAndMergeContents(contents, maxLength = 2000) {
+    let chunks = [];
+    let tempChunks = contents.split('\n');
+    let currentChunk = "";
+
+    for (let chunk of tempChunks) {
+        // If adding the current chunk exceeds the limit, push the accumulated chunk
+        if ((currentChunk + chunk + '\n').length > maxLength) {
+            chunks.push(currentChunk.trim());
+            currentChunk = chunk + '\n';
+        } else {
+            currentChunk += chunk + '\n';
+        }
+    }
+
+    // Push the remaining chunk
+    if (currentChunk.trim().length > 0) {
+        chunks.push(currentChunk.trim());
+    }
+
+    // Further split any chunk that still exceeds maxLength using `.`
+    let finalChunks = [];
+    for (let chunk of chunks) {
+        if (chunk.length > maxLength) {
+            let subChunks = chunk.split('.');
+            let mergedChunk = "";
+
+            for (let subChunk of subChunks) {
+                if ((mergedChunk + subChunk + '.').length > maxLength) {
+                    finalChunks.push(mergedChunk.trim());
+                    mergedChunk = subChunk + '.';
+                } else {
+                    mergedChunk += subChunk + '.';
+                }
+            }
+
+            // Push the remaining part
+            if (mergedChunk.trim().length > 0) {
+                finalChunks.push(mergedChunk.trim());
+            }
+        } else {
+            finalChunks.push(chunk);
+        }
+    }
+
+    return finalChunks;
+}
+
 export async function createPage(client, name, contents, parentPageId) {
+    const contentChunks = sliceAndMergeContents(contents);
+
+    const children = contentChunks.map(chunk => ({
+        object: "block",
+        type: "paragraph",
+        paragraph: {
+            rich_text: [{ type: "text", text: { content: chunk } }],
+        },
+    }));
+
+    // Create the page with sliced chunks as children
     const page = await client.pages.create({
         parent: {
             page_id: parentPageId,
         },
         properties: {
-            title: [{type: "text", text: {content: name}}],
+            title: [{ type: "text", text: { content: name } }],
         },
-        children: [{
-            paragraph: {
-                rich_text: [{type: "text", text: {content: contents}}],
-            }
-        }]
-    })
-    console.log(`Created page with ID: ${page.id}`)
+        children: children,
+    });
+
+    console.log(`Created page with ID: ${page.id}`);
 }
 
 export async function printPageProperties(client, id) {


### PR DESCRIPTION
This PR aims to fix issue https://github.com/otto8-ai/otto8/issues/627.

*What is fixed*:
the `CreatePage` tool now will check the length of input content, and if it's greater than the limit(2000), the tool will slice the content into smaller chunks as multiple rich_texts of the the children block of the page.

<img width="1699" alt="Screenshot 2024-12-06 at 8 23 36 AM" src="https://github.com/user-attachments/assets/b850a1df-19b4-4e41-a30a-0a732d4b7281">
