### PR TITLE
fix: support copying generated image files

### DIFF
--- a/workspace-files/tool.gpt
+++ b/workspace-files/tool.gpt
@@ -3,7 +3,7 @@ Description: Adds the capability for users to read and write workspace files
 Type: context
 Metadata: category: Utilities
 Context: workspace_list
-Share Tools: workspace_read, workspace_write
+Share Tools: workspace_read, workspace_write, workspace_copy
 Share Input Filter: input_parse
 
 #!/bin/bash
@@ -16,8 +16,8 @@ fi
 cat << EOF
 # START INSTRUCTIONS: "Workspace Files"
 
-You have the ability to read and write files in a workspace which is specific to your user. Use the given
-workspace_read and workspace_write tools to interact with files. The files that you write are available for the user
+You have the ability to read, write, and copy files in a workspace which is specific to your user. Use the given
+workspace_read, workspace_write, and workspace_copy tools to interact with files. The files that you write are available for the user
 to read and write in their user interface. You can collaborate with the user by reading and writing these files.
 Do not ask first to create files in the workspace. Immediately write contents to the workspace as opposed to describing
 the contents to the user. If the user changes a file, they will inform you that content has changed, with the new
@@ -47,6 +47,14 @@ Params: filename: The filename to write to
 Params: content: The contents to write to the file
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool write
+
+---
+Name: workspace_copy
+Description: Copy the contents of a file to a new filename
+Params: filename: The filename to copy from
+Params: to_filename: The new filename to copy to
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool copy
 
 ---
 Name: input_parse


### PR DESCRIPTION
Add the `workspace_copy` tool to the `Workspace Files` bundle in order to support copying workspace files without exposing their content to the LLM. This allows agents to copy large and/or non-UTF8 files and enables save generated images to files with more descriptive names.

Addresses https://github.com/otto8-ai/otto8/issues/514

**Note:** ~This change has me wondering if the `workspace_read` tool should output markdown with the URL format we use for displaying images in the `Images` bundle; e.g. -> `generated_image_4663217f.png` -> `![generated_image_4663217f.png](http://main.otto8.ai/api/threads/t12v4pt/file/generated_image_4663217f.png)`. The idea is for the UI to show the image on read instead of failing.~

**Note:** I’m feeling like this is the wrong approach since having the LLM read/write non-utf8 files directly isn’t tenable. I’m coming around to the idea that hiding these files and providing first-class naming/renaming support in the Images bundle is a more consistent solution.

